### PR TITLE
Use cookie for id, don't allow user to pass in id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/muse-components",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "MUSE component for unified PayPal/Braintree web sdk",
   "main": "index.js",
   "scripts": {

--- a/src/cookie-utils.js
+++ b/src/cookie-utils.js
@@ -1,23 +1,23 @@
 /* @flow */
 
-export const getCookie = (cname : string) : string => {
-    const name = `${ cname }=`;
-    const ca = document.cookie.split(';');
-    for (let i = 0; i < ca.length; i++) {
-        let c = ca[i];
-        while (c.charAt(0) === ' ') {
-            c = c.substring(1);
+export const getCookie = (cookieName : string) : string => {
+    const name = `${ cookieName }=`;
+    const cookies = document.cookie.split(';');
+    for (let i = 0; i < cookies.length; i++) {
+        let cookie = cookies[i];
+        while (cookie.charAt(0) === ' ') {
+            cookie = cookie.slice(1);
         }
-        if (c.indexOf(name) === 0) {
-            return c.substring(name.length, c.length);
+        if (cookie.indexOf(name) === 0) {
+            return cookie.slice(name.length, name.length + cookie.length);
         }
     }
     return '';
 };
 
-export const setCookie = (cname : string, cvalue : string, exMilliseconds : number) : void => {
+export const setCookie = (cookieName : string, cookieValue : string, expirationMilliseconds : number) : void => {
     const d = new Date();
-    d.setTime(d.getTime() + exMilliseconds);
+    d.setTime(d.getTime() + expirationMilliseconds);
     const expires = `expires=${ d.toUTCString() }`;
-    document.cookie = `${ cname }=${ cvalue }; Path=/; ${ expires }`;
+    document.cookie = `${ cookieName }=${ cookieValue }; Path=/; ${ expires }`;
 };

--- a/src/cookie-utils.js
+++ b/src/cookie-utils.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+export const getCookie = (cname : string) : string => {
+    const name = `${ cname }=`;
+    const ca = document.cookie.split(';');
+    for (let i = 0; i < ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) === ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) === 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return '';
+};
+
+export const setCookie = (cname : string, cvalue : string, exMilliseconds : number) : void => {
+    const d = new Date();
+    d.setTime(d.getTime() + exMilliseconds);
+    const expires = `expires=${ d.toUTCString() }`;
+    document.cookie = `${ cname }=${ cvalue }; Path=/; ${ expires }`;
+};

--- a/src/generate-id.js
+++ b/src/generate-id.js
@@ -1,0 +1,4 @@
+/* @flow */
+
+export const generateId = () : string =>
+    [ Math.random(), Math.random() ].map(x => x.toString(16).slice(2)).join('');

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -66,11 +66,19 @@ type Config = {|
     paramsToBeaconUrl? : ParamsToBeaconUrl
 |};
 
-const getUserId = () => {
-    return document.cookie ? document.cookie : localStorage.getItem('user-id');
+const getUserIdCookie = () : ?string => {
+    const userCookie = document.cookie.split(';').find(x => x.startsWith('paypal-cr-user'));
+    if (!userCookie) {
+        return;
+    }
+    return userCookie.split('=')[1];
 };
 
-const setRandomUserId = () => {
+const getUserId = () : ?string => {
+    return getUserIdCookie() || localStorage.getItem('user-id');
+};
+
+const setRandomUserId = () : void => {
     localStorage.setItem('user-id', generateId());
 };
 

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -75,11 +75,11 @@ const getUserIdCookie = () : ?string => {
 };
 
 const getUserId = () : ?string => {
-    return getUserIdCookie() || localStorage.getItem('user-id');
+    return getUserIdCookie() || localStorage.getItem('paypal-user-id');
 };
 
 const setRandomUserId = () : void => {
-    localStorage.setItem('user-id', generateId());
+    localStorage.setItem('paypal-user-id', generateId());
 };
 
 const track = <T>(config : Config, trackingType : TrackingType, trackingData : T) => {
@@ -135,7 +135,7 @@ export const Tracker = (config? : Config = { user: { email: undefined, name: und
             email: data.user.email || ((config && config.user) || {}).email,
             name:  data.user.name || ((config && config.user) || {}).name
         };
-        track(config, 'setUser', { oldUserId: localStorage.getItem('user-id') });
+        track(config, 'setUser', { oldUserId: localStorage.getItem('paypal-user-id') });
     },
     setProperty: (data : PropertyData) => {
         config.property = { id: data.property.id };

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -130,10 +130,13 @@ export const Tracker = (config? : Config = { user: { email: undefined, name: und
     removeFromCart: (data : RemoveCartData) => trackCartEvent(config, 'removeFromCart', data),
     purchase:       (data : PurchaseData) => track(config, 'purchase', data),
     setUser:        (data : UserData) => {
-        config.user = {
-            ...config.user,
-            email: data.user.email || ((config && config.user) || {}).email,
-            name:  data.user.name || ((config && config.user) || {}).name
+        config = {
+            ...config,
+            user: {
+                ...config.user,
+                email: data.user.email || ((config && config.user) || {}).email,
+                name:  data.user.name || ((config && config.user) || {}).name
+            }
         };
         track(config, 'setUser', { oldUserId: localStorage.getItem('paypal-user-id') });
     },

--- a/test/cookie-utils.js
+++ b/test/cookie-utils.js
@@ -8,7 +8,24 @@ import { getCookie, setCookie } from '../src/cookie-utils';
 describe('cookieUtils', () => {
     it('set the cookie you want to set', () => {
         expect(getCookie('__test__hello')).to.equal('');
-        setCookie('__test__hello', '__test__cookie-value', 1000);
+        setCookie('__test__hello', '__test__cookie-value', 10000);
         expect(getCookie('__test__hello')).to.equal('__test__cookie-value');
+    });
+
+    it('handles setting multiple cookie values', () => {
+        setCookie('__test__hello1', '__test__cookie-value1', 10000);
+        setCookie('__test__hello2', '__test__cookie-value2', 10000);
+        expect(getCookie('__test__hello1')).to.equal('__test__cookie-value1');
+        expect(getCookie('__test__hello2')).to.equal('__test__cookie-value2');
+    });
+
+    it('keeps the last value that was set as the cookie', () => {
+        setCookie('__test__hello1', '__test__cookie-value1', 10000);
+        setCookie('__test__hello1', '__test__cookie-value2', 10000);
+        expect(getCookie('__test__hello1')).to.equal('__test__cookie-value2');
+    });
+
+    it('returns an empty string if there is no cookie value', () => {
+        expect(getCookie('___test__some-cookie-we-have-not-set')).to.equal('');
     });
 });

--- a/test/cookie-utils.js
+++ b/test/cookie-utils.js
@@ -1,0 +1,14 @@
+/* globals describe it */
+/* @flow */
+
+import { expect } from 'chai';
+
+import { getCookie, setCookie } from '../src/cookie-utils';
+
+describe('cookieUtils', () => {
+    it('set the cookie you want to set', () => {
+        expect(getCookie('__test__hello')).to.equal('');
+        setCookie('__test__hello', '__test__cookie-value', 1000);
+        expect(getCookie('__test__hello')).to.equal('__test__cookie-value');
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -2,3 +2,4 @@
 
 export * from './component';
 export * from './tracker-component';
+export * from './cookie-utils';

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -389,7 +389,7 @@ describe('paypal.Tracker', () => {
     });
 
     it('should use localStorage value if it exists', () => {
-        localStorage.setItem('user-id', 'generated-user-id-123');
+        localStorage.setItem('paypal-user-id', 'generated-user-id-123');
         const tracker = Tracker();
         tracker.addToCart({
             cartId: '__test__cartId',
@@ -422,7 +422,7 @@ describe('paypal.Tracker', () => {
     });
 
     it('should use document.cookie value if it exists, not localStorage value', () => {
-        localStorage.setItem('user-id', 'generated-user-id-123');
+        localStorage.setItem('paypal-user-id', 'generated-user-id-123');
         document.cookie = 'paypal-cr-user=test-cookie-id';
         const tracker = Tracker();
         tracker.addToCart({

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -423,7 +423,7 @@ describe('paypal.Tracker', () => {
 
     it('should use document.cookie value if it exists, not localStorage value', () => {
         localStorage.setItem('user-id', 'generated-user-id-123');
-        document.cookie = 'cookie-id';
+        document.cookie = 'paypal-cr-user=test-cookie-id';
         const tracker = Tracker();
         tracker.addToCart({
             cartId: '__test__cartId',
@@ -447,7 +447,7 @@ describe('paypal.Tracker', () => {
                 total:           '12345.67',
                 currencyCode:    'USD',
                 cartEventType:   'addToCart',
-                user:            { id: 'cookie-id' },
+                user:            { id: 'test-cookie-id' },
                 trackingType:    'cartEvent',
                 clientId:        'abcxyz123',
                 merchantId:      'xyz,hij,lmno'

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -420,4 +420,39 @@ describe('paypal.Tracker', () => {
             })
         );
     });
+
+    it('should use document.cookie value if it exists, not localStorage value', () => {
+        localStorage.setItem('user-id', 'generated-user-id-123');
+        document.cookie = 'cookie-id';
+        const tracker = Tracker();
+        tracker.addToCart({
+            cartId: '__test__cartId',
+            items:  [
+                {
+                    id:  '__test__productId',
+                    url: 'https://example.com/__test__productId'
+                }
+            ],
+            emailCampaignId: '__test__emailCampaignId',
+            total:           '12345.67',
+            currencyCode:    'USD'
+        });
+        const dataParamObject = extractDataParam(imgMock.src);
+        // $FlowFixMe
+        expect(JSON.stringify(dataParamObject)).to.equal(
+            JSON.stringify({
+                cartId:          '__test__cartId',
+                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
+                emailCampaignId: '__test__emailCampaignId',
+                total:           '12345.67',
+                currencyCode:    'USD',
+                cartEventType:   'addToCart',
+                user:            { id: 'cookie-id' },
+                trackingType:    'cartEvent',
+                clientId:        'abcxyz123',
+                merchantId:      'xyz,hij,lmno'
+            })
+        );
+        document.cookie = '';
+    });
 });

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -356,7 +356,7 @@ describe('paypal.Tracker', () => {
 
     it('should send last user set with setUser', () => {
         const tracker = Tracker();
-        tracker.setUser({ user: { email: '__test__email1' } });
+        tracker.setUser({ user: { email: '__test__email1', name: '__test__name1' } });
         tracker.setUser({ user: { email: '__test__email2' } });
         tracker.addToCart({
             cartId: '__test__cartId',
@@ -380,7 +380,7 @@ describe('paypal.Tracker', () => {
                 total:           '12345.67',
                 currencyCode:    'USD',
                 cartEventType:   'addToCart',
-                user:            { email: '__test__email2', id: 'abc123' },
+                user:            { email: '__test__email2', name: '__test__name1', id: 'abc123' },
                 trackingType:    'cartEvent',
                 clientId:        'abcxyz123',
                 merchantId:      'xyz,hij,lmno'

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -4,6 +4,7 @@
 import { expect } from 'chai';
 
 import { Tracker } from '../src/tracker-component';
+import { setCookie } from '../src/cookie-utils';
 // eslint-disable-next-line import/no-namespace
 import * as generateIdModule from '../src/generate-id';
 
@@ -13,7 +14,10 @@ const decode = (encodedDataParam : string) : string => {
 
 const extractDataParam = (url : string) : string => {
     return decode(
-        (url.match(/\?data=(.+)$/) || [ '', encodeURIComponent(btoa(JSON.stringify({}))) ])[1]
+        (url.match(/\?data=(.+)$/) || [
+            '',
+            encodeURIComponent(btoa(JSON.stringify({})))
+        ])[1]
     );
 };
 
@@ -124,8 +128,13 @@ describe('paypal.Tracker', () => {
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                cartId:          '__test__cartId',
-                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
+                cartId: '__test__cartId',
+                items:  [
+                    {
+                        id:  '__test__productId',
+                        url: 'https://example.com/__test__productId'
+                    }
+                ],
                 emailCampaignId: '__test__emailCampaignId',
                 total:           '12345.67',
                 currencyCode:    'USD',
@@ -165,8 +174,13 @@ describe('paypal.Tracker', () => {
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                cartId:          '__test__cartId',
-                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
+                cartId: '__test__cartId',
+                items:  [
+                    {
+                        id:  '__test__productId',
+                        url: 'https://example.com/__test__productId'
+                    }
+                ],
                 emailCampaignId: '__test__emailCampaignId',
                 total:           '12345.67',
                 currencyCode:    'USD',
@@ -203,8 +217,13 @@ describe('paypal.Tracker', () => {
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                cartId:        '__test__cartId',
-                items:         [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
+                cartId: '__test__cartId',
+                items:  [
+                    {
+                        id:  '__test__productId',
+                        url: 'https://example.com/__test__productId'
+                    }
+                ],
                 cartEventType: 'removeFromCart',
                 user:          {
                     email: '__test__email5@gmail.com',
@@ -292,8 +311,12 @@ describe('paypal.Tracker', () => {
         expect(appendChildCalls).to.equal(1);
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                oldUserId:    'abc123',
-                user:         { email: '__test__email9', name: '__test__userName9', id: 'abc123' },
+                oldUserId: 'abc123',
+                user:      {
+                    email: '__test__email9',
+                    name:  '__test__userName9',
+                    id:    'abc123'
+                },
                 trackingType: 'setUser',
                 clientId:     'abcxyz123',
                 merchantId:   'xyz,hij,lmno'
@@ -307,8 +330,12 @@ describe('paypal.Tracker', () => {
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                page:         '/test2',
-                user:         { email: '__test__email9', name: '__test__userName9', id: 'abc123' },
+                page: '/test2',
+                user: {
+                    email: '__test__email9',
+                    name:  '__test__userName9',
+                    id:    'abc123'
+                },
                 trackingType: 'view',
                 clientId:     'abcxyz123',
                 merchantId:   'xyz,hij,lmno'
@@ -345,8 +372,12 @@ describe('paypal.Tracker', () => {
         // $FlowFixMe
         expect(JSON.stringify(dataParamObject)).to.equal(
             JSON.stringify({
-                oldUserId:    'abc123',
-                user:         { email: '__test__email@gmail.com', name: '__test__name', id: 'abc123' },
+                oldUserId: 'abc123',
+                user:      {
+                    email: '__test__email@gmail.com',
+                    name:  '__test__name',
+                    id:    'abc123'
+                },
                 trackingType: 'setUser',
                 clientId:     'abcxyz123',
                 merchantId:   'xyz,hij,lmno'
@@ -356,7 +387,9 @@ describe('paypal.Tracker', () => {
 
     it('should send last user set with setUser', () => {
         const tracker = Tracker();
-        tracker.setUser({ user: { email: '__test__email1', name: '__test__name1' } });
+        tracker.setUser({
+            user: { email: '__test__email1', name: '__test__name1' }
+        });
         tracker.setUser({ user: { email: '__test__email2' } });
         tracker.addToCart({
             cartId: '__test__cartId',
@@ -374,22 +407,31 @@ describe('paypal.Tracker', () => {
         // $FlowFixMe
         expect(JSON.stringify(dataParamObject)).to.equal(
             JSON.stringify({
-                cartId:          '__test__cartId',
-                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
+                cartId: '__test__cartId',
+                items:  [
+                    {
+                        id:  '__test__productId',
+                        url: 'https://example.com/__test__productId'
+                    }
+                ],
                 emailCampaignId: '__test__emailCampaignId',
                 total:           '12345.67',
                 currencyCode:    'USD',
                 cartEventType:   'addToCart',
-                user:            { email: '__test__email2', name: '__test__name1', id: 'abc123' },
-                trackingType:    'cartEvent',
-                clientId:        'abcxyz123',
-                merchantId:      'xyz,hij,lmno'
+                user:            {
+                    email: '__test__email2',
+                    name:  '__test__name1',
+                    id:    'abc123'
+                },
+                trackingType: 'cartEvent',
+                clientId:     'abcxyz123',
+                merchantId:   'xyz,hij,lmno'
             })
         );
     });
 
-    it('should use localStorage value if it exists', () => {
-        localStorage.setItem('paypal-user-id', 'generated-user-id-123');
+    it('should use document.cookie value if it exists', () => {
+        setCookie('paypal-user-id', '__test__cookie-id', 10000);
         const tracker = Tracker();
         tracker.addToCart({
             cartId: '__test__cartId',
@@ -407,52 +449,22 @@ describe('paypal.Tracker', () => {
         // $FlowFixMe
         expect(JSON.stringify(dataParamObject)).to.equal(
             JSON.stringify({
-                cartId:          '__test__cartId',
-                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
+                cartId: '__test__cartId',
+                items:  [
+                    {
+                        id:  '__test__productId',
+                        url: 'https://example.com/__test__productId'
+                    }
+                ],
                 emailCampaignId: '__test__emailCampaignId',
                 total:           '12345.67',
                 currencyCode:    'USD',
                 cartEventType:   'addToCart',
-                user:            { id: 'generated-user-id-123' },
+                user:            { id: '__test__cookie-id' },
                 trackingType:    'cartEvent',
                 clientId:        'abcxyz123',
                 merchantId:      'xyz,hij,lmno'
             })
         );
-    });
-
-    it('should use document.cookie value if it exists, not localStorage value', () => {
-        localStorage.setItem('paypal-user-id', 'generated-user-id-123');
-        document.cookie = 'paypal-cr-user=test-cookie-id';
-        const tracker = Tracker();
-        tracker.addToCart({
-            cartId: '__test__cartId',
-            items:  [
-                {
-                    id:  '__test__productId',
-                    url: 'https://example.com/__test__productId'
-                }
-            ],
-            emailCampaignId: '__test__emailCampaignId',
-            total:           '12345.67',
-            currencyCode:    'USD'
-        });
-        const dataParamObject = extractDataParam(imgMock.src);
-        // $FlowFixMe
-        expect(JSON.stringify(dataParamObject)).to.equal(
-            JSON.stringify({
-                cartId:          '__test__cartId',
-                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
-                emailCampaignId: '__test__emailCampaignId',
-                total:           '12345.67',
-                currencyCode:    'USD',
-                cartEventType:   'addToCart',
-                user:            { id: 'test-cookie-id' },
-                trackingType:    'cartEvent',
-                clientId:        'abcxyz123',
-                merchantId:      'xyz,hij,lmno'
-            })
-        );
-        document.cookie = '';
     });
 });

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -4,6 +4,8 @@
 import { expect } from 'chai';
 
 import { Tracker } from '../src/tracker-component';
+// eslint-disable-next-line import/no-namespace
+import * as generateIdModule from '../src/generate-id';
 
 const decode = (encodedDataParam : string) : string => {
     return JSON.parse(atob(decodeURIComponent(encodedDataParam)));
@@ -11,10 +13,7 @@ const decode = (encodedDataParam : string) : string => {
 
 const extractDataParam = (url : string) : string => {
     return decode(
-        (url.match(/\?data=(.+)$/) || [
-            '',
-            encodeURIComponent(btoa(JSON.stringify({})))
-        ])[1]
+        (url.match(/\?data=(.+)$/) || [ '', encodeURIComponent(btoa(JSON.stringify({}))) ])[1]
     );
 };
 
@@ -41,11 +40,14 @@ describe('paypal.Tracker', () => {
     const originalDocumentBodyAppendChild = document.body.appendChild;
     // $FlowFixMe
     const originalDocumentCreateElement = document.createElement;
+    const originalGenerateId = generateIdModule.generateId;
     before(() => {
         // $FlowFixMe
         document.body.appendChild = appendChild;
         // $FlowFixMe
         document.createElement = createElement;
+        // $FlowFixMe
+        generateIdModule.generateId = () => 'abc123'; // eslint-disable-line import/namespace
     });
 
     after(() => {
@@ -53,6 +55,8 @@ describe('paypal.Tracker', () => {
         document.body.appendChild = originalDocumentBodyAppendChild;
         // $FlowFixMe
         document.createElement = originalDocumentCreateElement;
+        // $FlowFixMe
+        generateIdModule.generateId = originalGenerateId; // eslint-disable-line import/namespace
     });
 
     afterEach(() => {
@@ -61,9 +65,7 @@ describe('paypal.Tracker', () => {
     });
 
     it('should be a function that returns a tracker', () => {
-        const userID = '__test__userID';
-        const userName = '__test__userName';
-        const tracker = Tracker({ user: { id: userID, name: userName } });
+        const tracker = Tracker();
         expect(tracker).to.have.property('view');
         expect(tracker).to.have.property('addToCart');
         expect(tracker).to.have.property('setCart');
@@ -72,22 +74,26 @@ describe('paypal.Tracker', () => {
     });
 
     it('should send view events', () => {
-        const userID = '__test__userID2';
+        const email = '__test__email2@gmail.com';
         const userName = '__test__userName2';
-        const tracker = Tracker({ user: { id: userID, name: userName } });
+        const tracker = Tracker({ user: { email, name: userName } });
         expect(appendChildCalls).to.equal(0);
         tracker.view({
             page:  '/test2/apples',
             title: 'apples'
         });
         expect(imgMock.src).to.equal(
-            'https://www.paypal.com/targeting/track/view?data=eyJwYWdlIjoiL3Rlc3QyL2FwcGxlcyIsInRpdGxlIjoiYXBwbGVzIiwidXNlciI6eyJpZCI6Il9fdGVzdF9fdXNlcklEMiIsIm5hbWUiOiJfX3Rlc3RfX3VzZXJOYW1lMiJ9LCJ0cmFja2luZ1R5cGUiOiJ2aWV3IiwiY2xpZW50SWQiOiJhYmN4eXoxMjMiLCJtZXJjaGFudElkIjoieHl6LGhpaixsbW5vIn0%3D'
+            'https://www.paypal.com/targeting/track/view?data=eyJwYWdlIjoiL3Rlc3QyL2FwcGxlcyIsInRpdGxlIjoiYXBwbGVzIiwidXNlciI6eyJlbWFpbCI6Il9fdGVzdF9fZW1haWwyQGdtYWlsLmNvbSIsIm5hbWUiOiJfX3Rlc3RfX3VzZXJOYW1lMiIsImlkIjoiYWJjMTIzIn0sInRyYWNraW5nVHlwZSI6InZpZXciLCJjbGllbnRJZCI6ImFiY3h5ejEyMyIsIm1lcmNoYW50SWQiOiJ4eXosaGlqLGxtbm8ifQ%3D%3D'
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                page:         '/test2/apples',
-                title:        'apples',
-                user:         { id: '__test__userID2', name: '__test__userName2' },
+                page:  '/test2/apples',
+                title: 'apples',
+                user:  {
+                    email: '__test__email2@gmail.com',
+                    name:  '__test__userName2',
+                    id:    'abc123'
+                },
                 trackingType: 'view',
                 clientId:     'abcxyz123',
                 merchantId:   'xyz,hij,lmno'
@@ -97,9 +103,9 @@ describe('paypal.Tracker', () => {
     });
 
     it('should send addToCart events', () => {
-        const userID = '__test__userID3';
+        const email = '__test__email3@gmail.com';
         const userName = '__test__userName3';
-        const tracker = Tracker({ user: { id: userID, name: userName } });
+        const tracker = Tracker({ user: { email, name: userName } });
         expect(appendChildCalls).to.equal(0);
         tracker.addToCart({
             cartId: '__test__cartId',
@@ -114,34 +120,33 @@ describe('paypal.Tracker', () => {
             currencyCode:    'USD'
         });
         expect(imgMock.src).to.equal(
-            'https://www.paypal.com/targeting/track/cartEvent?data=eyJjYXJ0SWQiOiJfX3Rlc3RfX2NhcnRJZCIsIml0ZW1zIjpbeyJpZCI6Il9fdGVzdF9fcHJvZHVjdElkIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9fX3Rlc3RfX3Byb2R1Y3RJZCJ9XSwiZW1haWxDYW1wYWlnbklkIjoiX190ZXN0X19lbWFpbENhbXBhaWduSWQiLCJ0b3RhbCI6IjEyMzQ1LjY3IiwiY3VycmVuY3lDb2RlIjoiVVNEIiwiY2FydEV2ZW50VHlwZSI6ImFkZFRvQ2FydCIsInVzZXIiOnsiaWQiOiJfX3Rlc3RfX3VzZXJJRDMiLCJuYW1lIjoiX190ZXN0X191c2VyTmFtZTMifSwidHJhY2tpbmdUeXBlIjoiY2FydEV2ZW50IiwiY2xpZW50SWQiOiJhYmN4eXoxMjMiLCJtZXJjaGFudElkIjoieHl6LGhpaixsbW5vIn0%3D'
+            'https://www.paypal.com/targeting/track/cartEvent?data=eyJjYXJ0SWQiOiJfX3Rlc3RfX2NhcnRJZCIsIml0ZW1zIjpbeyJpZCI6Il9fdGVzdF9fcHJvZHVjdElkIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9fX3Rlc3RfX3Byb2R1Y3RJZCJ9XSwiZW1haWxDYW1wYWlnbklkIjoiX190ZXN0X19lbWFpbENhbXBhaWduSWQiLCJ0b3RhbCI6IjEyMzQ1LjY3IiwiY3VycmVuY3lDb2RlIjoiVVNEIiwiY2FydEV2ZW50VHlwZSI6ImFkZFRvQ2FydCIsInVzZXIiOnsiZW1haWwiOiJfX3Rlc3RfX2VtYWlsM0BnbWFpbC5jb20iLCJuYW1lIjoiX190ZXN0X191c2VyTmFtZTMiLCJpZCI6ImFiYzEyMyJ9LCJ0cmFja2luZ1R5cGUiOiJjYXJ0RXZlbnQiLCJjbGllbnRJZCI6ImFiY3h5ejEyMyIsIm1lcmNoYW50SWQiOiJ4eXosaGlqLGxtbm8ifQ%3D%3D'
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                cartId: '__test__cartId',
-                items:  [
-                    {
-                        id:  '__test__productId',
-                        url: 'https://example.com/__test__productId'
-                    }
-                ],
+                cartId:          '__test__cartId',
+                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
                 emailCampaignId: '__test__emailCampaignId',
                 total:           '12345.67',
                 currencyCode:    'USD',
                 cartEventType:   'addToCart',
-                user:            { id: '__test__userID3', name: '__test__userName3' },
-                trackingType:    'cartEvent',
-                clientId:        'abcxyz123',
-                merchantId:      'xyz,hij,lmno'
+                user:            {
+                    email: '__test__email3@gmail.com',
+                    name:  '__test__userName3',
+                    id:    'abc123'
+                },
+                trackingType: 'cartEvent',
+                clientId:     'abcxyz123',
+                merchantId:   'xyz,hij,lmno'
             })
         );
         expect(appendChildCalls).to.equal(1);
     });
 
     it('should send setCart events', () => {
-        const userID = '__test__userID4';
+        const email = '__test__email4@gmail.com';
         const userName = '__test__userName4';
-        const tracker = Tracker({ user: { id: userID, name: userName } });
+        const tracker = Tracker({ user: { email, name: userName } });
         expect(appendChildCalls).to.equal(0);
         tracker.setCart({
             cartId: '__test__cartId',
@@ -156,34 +161,33 @@ describe('paypal.Tracker', () => {
             currencyCode:    'USD'
         });
         expect(imgMock.src).to.equal(
-            'https://www.paypal.com/targeting/track/cartEvent?data=eyJjYXJ0SWQiOiJfX3Rlc3RfX2NhcnRJZCIsIml0ZW1zIjpbeyJpZCI6Il9fdGVzdF9fcHJvZHVjdElkIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9fX3Rlc3RfX3Byb2R1Y3RJZCJ9XSwiZW1haWxDYW1wYWlnbklkIjoiX190ZXN0X19lbWFpbENhbXBhaWduSWQiLCJ0b3RhbCI6IjEyMzQ1LjY3IiwiY3VycmVuY3lDb2RlIjoiVVNEIiwiY2FydEV2ZW50VHlwZSI6InNldENhcnQiLCJ1c2VyIjp7ImlkIjoiX190ZXN0X191c2VySUQ0IiwibmFtZSI6Il9fdGVzdF9fdXNlck5hbWU0In0sInRyYWNraW5nVHlwZSI6ImNhcnRFdmVudCIsImNsaWVudElkIjoiYWJjeHl6MTIzIiwibWVyY2hhbnRJZCI6Inh5eixoaWosbG1ubyJ9'
+            'https://www.paypal.com/targeting/track/cartEvent?data=eyJjYXJ0SWQiOiJfX3Rlc3RfX2NhcnRJZCIsIml0ZW1zIjpbeyJpZCI6Il9fdGVzdF9fcHJvZHVjdElkIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9fX3Rlc3RfX3Byb2R1Y3RJZCJ9XSwiZW1haWxDYW1wYWlnbklkIjoiX190ZXN0X19lbWFpbENhbXBhaWduSWQiLCJ0b3RhbCI6IjEyMzQ1LjY3IiwiY3VycmVuY3lDb2RlIjoiVVNEIiwiY2FydEV2ZW50VHlwZSI6InNldENhcnQiLCJ1c2VyIjp7ImVtYWlsIjoiX190ZXN0X19lbWFpbDRAZ21haWwuY29tIiwibmFtZSI6Il9fdGVzdF9fdXNlck5hbWU0IiwiaWQiOiJhYmMxMjMifSwidHJhY2tpbmdUeXBlIjoiY2FydEV2ZW50IiwiY2xpZW50SWQiOiJhYmN4eXoxMjMiLCJtZXJjaGFudElkIjoieHl6LGhpaixsbW5vIn0%3D'
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                cartId: '__test__cartId',
-                items:  [
-                    {
-                        id:  '__test__productId',
-                        url: 'https://example.com/__test__productId'
-                    }
-                ],
+                cartId:          '__test__cartId',
+                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
                 emailCampaignId: '__test__emailCampaignId',
                 total:           '12345.67',
                 currencyCode:    'USD',
                 cartEventType:   'setCart',
-                user:            { id: '__test__userID4', name: '__test__userName4' },
-                trackingType:    'cartEvent',
-                clientId:        'abcxyz123',
-                merchantId:      'xyz,hij,lmno'
+                user:            {
+                    email: '__test__email4@gmail.com',
+                    name:  '__test__userName4',
+                    id:    'abc123'
+                },
+                trackingType: 'cartEvent',
+                clientId:     'abcxyz123',
+                merchantId:   'xyz,hij,lmno'
             })
         );
         expect(appendChildCalls).to.equal(1);
     });
 
     it('should send removeFromCart events', () => {
-        const userID = '__test__userID5';
+        const email = '__test__email5@gmail.com';
         const userName = '__test__userName5';
-        const tracker = Tracker({ user: { id: userID, name: userName } });
+        const tracker = Tracker({ user: { email, name: userName } });
         expect(appendChildCalls).to.equal(0);
         tracker.removeFromCart({
             cartId: '__test__cartId',
@@ -195,42 +199,45 @@ describe('paypal.Tracker', () => {
             ]
         });
         expect(imgMock.src).to.equal(
-            'https://www.paypal.com/targeting/track/cartEvent?data=eyJjYXJ0SWQiOiJfX3Rlc3RfX2NhcnRJZCIsIml0ZW1zIjpbeyJpZCI6Il9fdGVzdF9fcHJvZHVjdElkIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9fX3Rlc3RfX3Byb2R1Y3RJZCJ9XSwiY2FydEV2ZW50VHlwZSI6InJlbW92ZUZyb21DYXJ0IiwidXNlciI6eyJpZCI6Il9fdGVzdF9fdXNlcklENSIsIm5hbWUiOiJfX3Rlc3RfX3VzZXJOYW1lNSJ9LCJ0cmFja2luZ1R5cGUiOiJjYXJ0RXZlbnQiLCJjbGllbnRJZCI6ImFiY3h5ejEyMyIsIm1lcmNoYW50SWQiOiJ4eXosaGlqLGxtbm8ifQ%3D%3D'
+            'https://www.paypal.com/targeting/track/cartEvent?data=eyJjYXJ0SWQiOiJfX3Rlc3RfX2NhcnRJZCIsIml0ZW1zIjpbeyJpZCI6Il9fdGVzdF9fcHJvZHVjdElkIiwidXJsIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9fX3Rlc3RfX3Byb2R1Y3RJZCJ9XSwiY2FydEV2ZW50VHlwZSI6InJlbW92ZUZyb21DYXJ0IiwidXNlciI6eyJlbWFpbCI6Il9fdGVzdF9fZW1haWw1QGdtYWlsLmNvbSIsIm5hbWUiOiJfX3Rlc3RfX3VzZXJOYW1lNSIsImlkIjoiYWJjMTIzIn0sInRyYWNraW5nVHlwZSI6ImNhcnRFdmVudCIsImNsaWVudElkIjoiYWJjeHl6MTIzIiwibWVyY2hhbnRJZCI6Inh5eixoaWosbG1ubyJ9'
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                cartId: '__test__cartId',
-                items:  [
-                    {
-                        id:  '__test__productId',
-                        url: 'https://example.com/__test__productId'
-                    }
-                ],
+                cartId:        '__test__cartId',
+                items:         [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
                 cartEventType: 'removeFromCart',
-                user:          { id: '__test__userID5', name: '__test__userName5' },
-                trackingType:  'cartEvent',
-                clientId:      'abcxyz123',
-                merchantId:    'xyz,hij,lmno'
+                user:          {
+                    email: '__test__email5@gmail.com',
+                    name:  '__test__userName5',
+                    id:    'abc123'
+                },
+                trackingType: 'cartEvent',
+                clientId:     'abcxyz123',
+                merchantId:   'xyz,hij,lmno'
             })
         );
         expect(appendChildCalls).to.equal(1);
     });
 
     it('should send purchase events', () => {
-        const userID = '__test__userID6';
+        const email = '__test__email6@gmail.com';
         const userName = '__test__userName6';
-        const tracker = Tracker({ user: { id: userID, name: userName } });
+        const tracker = Tracker({ user: { email, name: userName } });
         expect(appendChildCalls).to.equal(0);
         tracker.purchase({
             cartId: '__test__cartId'
         });
         expect(imgMock.src).to.equal(
-            'https://www.paypal.com/targeting/track/purchase?data=eyJjYXJ0SWQiOiJfX3Rlc3RfX2NhcnRJZCIsInVzZXIiOnsiaWQiOiJfX3Rlc3RfX3VzZXJJRDYiLCJuYW1lIjoiX190ZXN0X191c2VyTmFtZTYifSwidHJhY2tpbmdUeXBlIjoicHVyY2hhc2UiLCJjbGllbnRJZCI6ImFiY3h5ejEyMyIsIm1lcmNoYW50SWQiOiJ4eXosaGlqLGxtbm8ifQ%3D%3D'
+            'https://www.paypal.com/targeting/track/purchase?data=eyJjYXJ0SWQiOiJfX3Rlc3RfX2NhcnRJZCIsInVzZXIiOnsiZW1haWwiOiJfX3Rlc3RfX2VtYWlsNkBnbWFpbC5jb20iLCJuYW1lIjoiX190ZXN0X191c2VyTmFtZTYiLCJpZCI6ImFiYzEyMyJ9LCJ0cmFja2luZ1R5cGUiOiJwdXJjaGFzZSIsImNsaWVudElkIjoiYWJjeHl6MTIzIiwibWVyY2hhbnRJZCI6Inh5eixoaWosbG1ubyJ9'
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                cartId:       '__test__cartId',
-                user:         { id: '__test__userID6', name: '__test__userName6' },
+                cartId: '__test__cartId',
+                user:   {
+                    email: '__test__email6@gmail.com',
+                    name:  '__test__userName6',
+                    id:    'abc123'
+                },
                 trackingType: 'purchase',
                 clientId:     'abcxyz123',
                 merchantId:   'xyz,hij,lmno'
@@ -240,7 +247,6 @@ describe('paypal.Tracker', () => {
     });
 
     it('should call paramsToBeaconUrl to create the url if you pass in paramsToBeaconUrl function', () => {
-        const userID = '__test__userID6';
         const userName = '__test__userName6';
         let calledArgs;
         const paramsToBeaconUrl = (...args) => {
@@ -248,7 +254,7 @@ describe('paypal.Tracker', () => {
             return 'https://example.com/picture';
         };
         const tracker = Tracker({
-            user: { id: userID, name: userName },
+            user: { email: '__test__email@gmail.com', name: userName },
             paramsToBeaconUrl
         });
         expect(appendChildCalls).to.equal(0);
@@ -264,8 +270,9 @@ describe('paypal.Tracker', () => {
                     data:         {
                         cartId: '__test__cartId',
                         user:   {
-                            id:   '__test__userID6',
-                            name: '__test__userName6'
+                            email: '__test__email@gmail.com',
+                            name:  '__test__userName6',
+                            id:    'abc123'
                         },
                         trackingType: 'purchase',
                         clientId:     'abcxyz123',
@@ -277,21 +284,16 @@ describe('paypal.Tracker', () => {
     });
 
     it('should set the user', () => {
-        const userID = '__test__userID9';
         const userName = '__test__userName9';
         const email = '__test__email9';
-        const tracker = Tracker({ user: { id: userID } });
+        const tracker = Tracker();
         expect(appendChildCalls).to.equal(0);
-        tracker.setUser({ user: { id: userID, name: userName, email } });
+        tracker.setUser({ user: { name: userName, email } });
         expect(appendChildCalls).to.equal(1);
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                oldUserId: '__test__userID9',
-                user:      {
-                    id:    '__test__userID9',
-                    email: '__test__email9',
-                    name:  '__test__userName9'
-                },
+                oldUserId:    'abc123',
+                user:         { email: '__test__email9', name: '__test__userName9', id: 'abc123' },
                 trackingType: 'setUser',
                 clientId:     'abcxyz123',
                 merchantId:   'xyz,hij,lmno'
@@ -301,16 +303,12 @@ describe('paypal.Tracker', () => {
             page: '/test2'
         });
         expect(imgMock.src).to.equal(
-            'https://www.paypal.com/targeting/track/view?data=eyJwYWdlIjoiL3Rlc3QyIiwidXNlciI6eyJpZCI6Il9fdGVzdF9fdXNlcklEOSIsImVtYWlsIjoiX190ZXN0X19lbWFpbDkiLCJuYW1lIjoiX190ZXN0X191c2VyTmFtZTkifSwidHJhY2tpbmdUeXBlIjoidmlldyIsImNsaWVudElkIjoiYWJjeHl6MTIzIiwibWVyY2hhbnRJZCI6Inh5eixoaWosbG1ubyJ9'
+            'https://www.paypal.com/targeting/track/view?data=eyJwYWdlIjoiL3Rlc3QyIiwidXNlciI6eyJlbWFpbCI6Il9fdGVzdF9fZW1haWw5IiwibmFtZSI6Il9fdGVzdF9fdXNlck5hbWU5IiwiaWQiOiJhYmMxMjMifSwidHJhY2tpbmdUeXBlIjoidmlldyIsImNsaWVudElkIjoiYWJjeHl6MTIzIiwibWVyY2hhbnRJZCI6Inh5eixoaWosbG1ubyJ9'
         );
         expect(JSON.stringify(extractDataParam(imgMock.src))).to.equal(
             JSON.stringify({
-                page: '/test2',
-                user: {
-                    id:    '__test__userID9',
-                    email: '__test__email9',
-                    name:  '__test__userName9'
-                },
+                page:         '/test2',
+                user:         { email: '__test__email9', name: '__test__userName9', id: 'abc123' },
                 trackingType: 'view',
                 clientId:     'abcxyz123',
                 merchantId:   'xyz,hij,lmno'
@@ -332,14 +330,12 @@ describe('paypal.Tracker', () => {
     it('should allow you to instantiate a user and then set the user', () => {
         const tracker = Tracker({
             user: {
-                id:    '__test__oldUserId',
-                email: '__test__oldEmail@gmail.com'
+                email: '__test__oldEmail333@gmail.com'
             }
         });
         expect(appendChildCalls).to.equal(0);
         tracker.setUser({
             user: {
-                id:    '__test__newUserId',
                 email: '__test__email@gmail.com',
                 name:  '__test__name'
             }
@@ -349,15 +345,45 @@ describe('paypal.Tracker', () => {
         // $FlowFixMe
         expect(JSON.stringify(dataParamObject)).to.equal(
             JSON.stringify({
-                oldUserId: '__test__oldUserId',
-                user:      {
-                    id:    '__test__newUserId',
-                    email: '__test__email@gmail.com',
-                    name:  '__test__name'
-                },
+                oldUserId:    'abc123',
+                user:         { email: '__test__email@gmail.com', name: '__test__name', id: 'abc123' },
                 trackingType: 'setUser',
                 clientId:     'abcxyz123',
                 merchantId:   'xyz,hij,lmno'
+            })
+        );
+    });
+
+    it('should send last user set with setUser', () => {
+        const tracker = Tracker();
+        tracker.setUser({ user: { email: '__test__email1' } });
+        tracker.setUser({ user: { email: '__test__email2' } });
+        tracker.addToCart({
+            cartId: '__test__cartId',
+            items:  [
+                {
+                    id:  '__test__productId',
+                    url: 'https://example.com/__test__productId'
+                }
+            ],
+            emailCampaignId: '__test__emailCampaignId',
+            total:           '12345.67',
+            currencyCode:    'USD'
+        });
+        const dataParamObject = extractDataParam(imgMock.src);
+        // $FlowFixMe
+        expect(JSON.stringify(dataParamObject)).to.equal(
+            JSON.stringify({
+                cartId:          '__test__cartId',
+                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
+                emailCampaignId: '__test__emailCampaignId',
+                total:           '12345.67',
+                currencyCode:    'USD',
+                cartEventType:   'addToCart',
+                user:            { email: '__test__email2', id: 'abc123' },
+                trackingType:    'cartEvent',
+                clientId:        'abcxyz123',
+                merchantId:      'xyz,hij,lmno'
             })
         );
     });

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -387,4 +387,37 @@ describe('paypal.Tracker', () => {
             })
         );
     });
+
+    it('should use localStorage value if it exists', () => {
+        localStorage.setItem('user-id', 'generated-user-id-123');
+        const tracker = Tracker();
+        tracker.addToCart({
+            cartId: '__test__cartId',
+            items:  [
+                {
+                    id:  '__test__productId',
+                    url: 'https://example.com/__test__productId'
+                }
+            ],
+            emailCampaignId: '__test__emailCampaignId',
+            total:           '12345.67',
+            currencyCode:    'USD'
+        });
+        const dataParamObject = extractDataParam(imgMock.src);
+        // $FlowFixMe
+        expect(JSON.stringify(dataParamObject)).to.equal(
+            JSON.stringify({
+                cartId:          '__test__cartId',
+                items:           [ { id: '__test__productId', url: 'https://example.com/__test__productId' } ],
+                emailCampaignId: '__test__emailCampaignId',
+                total:           '12345.67',
+                currencyCode:    'USD',
+                cartEventType:   'addToCart',
+                user:            { id: 'generated-user-id-123' },
+                trackingType:    'cartEvent',
+                clientId:        'abcxyz123',
+                merchantId:      'xyz,hij,lmno'
+            })
+        );
+    });
 });


### PR DESCRIPTION
This makes it so the user never passes in an id, we generate it for them in all cases.

We get the id now from one of the following in order:
1. grab the id from document.cookie if it exists
2. if there's no id in document.cookie, we check localStorage
3. if there's no id in localStorage, the id gets generated and is put in localStorage then used as the id