### PR TITLE
feat(muse-spb): push event to paypalDDL when SPB renders

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { getClientID, getMerchantID, getPayPalDomain, getVersion, isPayPalDomain, getEnv } from '@paypal/sdk-client/src';
+import { getClientID, getMerchantID, getPayPalDomain, getVersion, isPayPalDomain, getEnv, getEventEmitter } from '@paypal/sdk-client/src';
 import { UNKNOWN, ENV } from '@paypal/sdk-constants/src';
 
 export const PPTM_ID = 'xo-pptm';
@@ -82,8 +82,18 @@ export function insertPptm() {
     }
 }
 
+function listenForButtonRender() {
+    getEventEmitter().on('button_render', () => {
+        window.paypalDDL = window.paypalDDL || [];
+        if (!window.paypalDDL.find(e => e.event === 'paypalButtonRender')) {
+            window.paypalDDL.push({ event: 'paypalButtonRender' });
+        }
+    });
+}
+
 export function setup() {
     document.addEventListener('DOMContentLoaded', insertPptm);
+    listenForButtonRender();
 
     const clientId = getClientID();
     const merchantId = parseMerchantId();

--- a/src/component.js
+++ b/src/component.js
@@ -85,7 +85,8 @@ export function insertPptm() {
 function listenForButtonRender() {
     getEventEmitter().on('button_render', () => {
         window.paypalDDL = window.paypalDDL || [];
-        if (!window.paypalDDL.find(e => e.event === 'paypalButtonRender')) {
+        const buttonRenderEvent = window.paypalDDL.filter(e => e.event === 'paypalButtonRender');
+        if (buttonRenderEvent.length === 0) {
             window.paypalDDL.push({ event: 'paypalButtonRender' });
         }
     });

--- a/test/component.js
+++ b/test/component.js
@@ -2,7 +2,7 @@
 /* @flow */
 
 import { ENV } from '@paypal/sdk-constants/src';
-import { getVersion } from '@paypal/sdk-client/src';
+import { getVersion, getEventEmitter } from '@paypal/sdk-client/src';
 import { expect } from 'chai';
 
 import * as component from '../src/component'; // eslint-disable-line import/no-namespace
@@ -52,6 +52,20 @@ describe('muse', () => {
 
             // $FlowFixMe
             expect(script).to.equal(null);
+        });
+
+        // $FlowFixMe
+        it('should push one and only one `paypalButtonRender` event to paypalDDL when button is rendered', () => {
+            component.setup();
+
+            // mock the case that paypal button renders multiple times
+            getEventEmitter().trigger('button_render');
+            getEventEmitter().trigger('button_render');
+
+            const renderEventQueue = window.paypalDDL.filter(e => e.event === 'paypalButtonRender');
+
+            // $FlowFixMe
+            expect(renderEventQueue.length).to.equal(1);
         });
     });
 


### PR DESCRIPTION
Payment SDK will emit a `button_render` event when SPB is rendered. 
Muse component will listen for that event and push a `paypalButtonRender` event to data layer, which will then trigger muse analytics-xo tag.