### PR TITLE
Fix bug with modal not showing up on different monitors

### DIFF
--- a/src/messaging-component.js
+++ b/src/messaging-component.js
@@ -58,7 +58,7 @@ export const Messaging = (...args : $ReadOnlyArray<{ cartRecovery : { userId : s
     }
     const exitIntentListener = debounce(e => {
         // $FlowFixMe
-        if (e.clientY <= 150) {
+        if (e.clientY <= 0) {
             showExitModal(...args);
         }
     }, 100);

--- a/src/messaging-component.js
+++ b/src/messaging-component.js
@@ -58,7 +58,7 @@ export const Messaging = (...args : $ReadOnlyArray<{ cartRecovery : { userId : s
     }
     const exitIntentListener = debounce(e => {
         // $FlowFixMe
-        if (e.screenY <= 150) {
+        if (e.clientY <= 150) {
             showExitModal(...args);
         }
     }, 100);

--- a/src/messaging-component.js
+++ b/src/messaging-component.js
@@ -58,7 +58,7 @@ export const Messaging = (...args : $ReadOnlyArray<{ cartRecovery : { userId : s
     }
     const exitIntentListener = debounce(e => {
         // $FlowFixMe
-        if (e.clientY <= 10 || e.clientY >= window.innerHeight - 10 || e.clientX <= 10 || e.clientX >= window.innerWidth - 10) {
+        if (e.clientY <= 10) {
             showExitModal(...args);
         }
     }, 100);

--- a/src/messaging-component.js
+++ b/src/messaging-component.js
@@ -58,7 +58,7 @@ export const Messaging = (...args : $ReadOnlyArray<{ cartRecovery : { userId : s
     }
     const exitIntentListener = debounce(e => {
         // $FlowFixMe
-        if (e.clientY <= 0) {
+        if (e.clientY <= 10 || e.clientY >= window.innerHeight - 10 || e.clientX <= 10 || e.clientX >= window.innerWidth - 10) {
             showExitModal(...args);
         }
     }, 100);


### PR DESCRIPTION
Change to clientY so that the modal will always show up whenever the user moves their mouse off the browser screen (since screenY won't work if the browser is on a different monitor) 