### PR TITLE
regression fix: view function must exist

### DIFF
--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -273,6 +273,7 @@ export const Tracker = (config? : Config = defaultTrackerConfig) => {
         JL.tracking(trackingConfig);
     }
     const trackers = {
+        view:       (data : ViewData) => () => {},
         addToCart:  (data : CartData) => {
             setCartCookie('add', data);
             return trackCartEvent(config, 'addToCart', data);

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -100,6 +100,7 @@ describe('paypal.Tracker', () => {
     // $FlowFixMe
     it('should be a function that returns a tracker', () => {
         const tracker = Tracker();
+        expect(tracker).to.have.property('view');
         expect(tracker).to.have.property('addToCart');
         expect(tracker).to.have.property('setCart');
         expect(tracker).to.have.property('removeFromCart');


### PR DESCRIPTION
Address this regression:

https://github.com/paypal/paypal-muse-components/pull/28/files

From a partner:
`... the tracker.view() method still hasn't been defined (despite being documented ...`