### PR TITLE
refactor(cart-storage): use localStorage to store cart and fix flow/lint errors

### DIFF
--- a/src/messaging-component.js
+++ b/src/messaging-component.js
@@ -30,7 +30,8 @@ const showExitModal = ({ cartRecovery }) => {
         return false;
     }
     // don't show modal if user has no cart items
-    const cart = JSON.parse(window.localStorage.getItem('paypal-cr-cart') || '{}');
+    // Prefer localStorage first, fallback to cookie (backwards compatibility -- this check can be removed a couple weeks after deploy).
+    const cart = JSON.parse(window.localStorage.getItem('paypal-cr-cart') || getCookie('paypal-cr-cart') || '{}');
     if (!cart.items) {
         return false;
     }

--- a/src/messaging-component.js
+++ b/src/messaging-component.js
@@ -30,7 +30,7 @@ const showExitModal = ({ cartRecovery }) => {
         return false;
     }
     // don't show modal if user has no cart items
-    const cart = JSON.parse(getCookie('paypal-cr-cart') || '{}');
+    const cart = JSON.parse(window.localStorage.getItem('paypal-cr-cart') || '{}');
     if (!cart.items) {
         return false;
     }

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -51,7 +51,8 @@ type UserData = {|
 
 type IdentityData = {|
     mrid : string,
-    onIdentification : Function
+    onIdentification : Function,
+    onError? : Function
 |};
 
 type ParamsToBeaconUrl = ({
@@ -86,6 +87,11 @@ type Config = {|
     |}
 |};
 
+const storage = {
+    paypalCrCart:       'paypal-cr-cart',
+    paypalCrCartExpiry: 'paypal-cr-cart-expiry'
+};
+
 const sevenDays = 6.048e+8;
 
 const accessTokenUrl = 'https://www.paypal.com/muse/api/partner-token';
@@ -99,22 +105,33 @@ const setRandomUserIdCookie = () : void => {
     setCookie('paypal-user-id', generate.generateId(), ONE_MONTH_IN_MILLISECONDS);
 };
 
-const setCartCookie = (type, data) : void => {
-    const currentCookie = getCookie('paypal-cr-cart');
-    if (type === 'add' && currentCookie !== '') {
-        const parsedCookie = JSON.parse(currentCookie);
-        const currentItems = parsedCookie && parsedCookie.items;
+const composeCart = (type, data) => {
+    const _data = { ...data };
+    const storedCart = window.localStorage.getItem(storage.paypalCrCart);
+    const expiry = window.localStorage.getItem(storage.paypalCrCartExpiry);
+
+    if (!expiry) {
+        window.localStorage.setItem(storage.paypalCrCartExpiry, Date.now() + sevenDays);
+    }
+
+    if (type === 'add' && storedCart !== null) {
+        const cart = JSON.parse(storedCart);
+        const currentItems = cart && cart.items;
+
         if (currentItems && currentItems.length) {
-            data.items = [
+            _data.items = [
                 ...currentItems,
                 ...data.items
             ];
         }
     }
-    setCookie('paypal-cr-cart', JSON.stringify(data), sevenDays);
+
+    window.localStorage.setItem(storage.paypalCrCart, JSON.stringify(_data));
+
+    return _data;
 };
 
-const getAccessToken = (url : string, mrid : string) : Promise<string> => {
+const getAccessToken = (url : string, mrid : string) : Promise<Object> => {
     return fetch(url, {
         method:      'POST',
         credentials: 'include',
@@ -219,23 +236,47 @@ const trackCartEvent = <T>(config : Config, cartEventType : CartEventType, track
 
 const defaultTrackerConfig = { user: { email: undefined, name: undefined } };
 
+const clearExpiredCart = () => {
+    const expiry = window.localStorage.getItem(storage.paypalCrCartExpiry);
+
+    if (expiry !== null) {
+        const expiryTime = Number(expiry);
+
+        if (Date.now() >= expiryTime) {
+            window.localStorage.removeItem(storage.paypalCrCartExpiry);
+            window.localStorage.removeItem(storage.paypalCrCart);
+        }
+    }
+};
+
 export const Tracker = (config? : Config = defaultTrackerConfig) => {
     /* PP Shopping tracker code breaks Safari. While we are debugging
      * the problem, disable trackers on Safari. Use the get param
-     * ?ppDebug=true to see logs, and ?ppEnableSafari to enable the functions 
+     * ?ppDebug=true to see logs, and ?ppEnableSafari to enable the functions
      * on Safari for debugging purposes.
      */
     const currentUrl = new URL(window.location.href);
     const debug = currentUrl.searchParams.get('ppDebug');
     const enableSafari = currentUrl.searchParams.get('ppEnableSafari');
-    // eslint-disable-next-line no-console
-    debug && console.log('PayPal Shopping: debug mode on.')
+    
+    if (debug) {
+        // eslint-disable-next-line no-console
+        console.log('PayPal Shopping: debug mode on.');
+    }
     
     const isSafari = (/^((?!chrome|android).)*safari/i).test(navigator.userAgent);
-    // eslint-disable-next-line no-console
-    debug && isSafari && console.log('PayPal Shopping: Safari detected.')
-    // eslint-disable-next-line no-console
-    debug && isSafari && enableSafari && console.log('PayPal Shopping: Safari trackers enabled.')
+
+    if (debug && isSafari) {
+        // eslint-disable-next-line no-console
+        console.log('PayPal Shopping: Safari detected.');
+    }
+
+    if (debug && isSafari && enableSafari) {
+        // eslint-disable-next-line no-console
+        console.log('PayPal Shopping: Safari trackers enabled.');
+    }
+
+    clearExpiredCart();
 
     const JL = getJetlore();
     const jetloreTrackTypes = [
@@ -273,14 +314,16 @@ export const Tracker = (config? : Config = defaultTrackerConfig) => {
         JL.tracking(trackingConfig);
     }
     const trackers = {
-        view:       (data : ViewData) => () => {},
+        view:       (data : ViewData) => () => {}, // eslint-disable-line no-unused-vars,no-empty-function
         addToCart:  (data : CartData) => {
-            setCartCookie('add', data);
-            return trackCartEvent(config, 'addToCart', data);
+            const newCart = composeCart('add', data);
+
+            return trackCartEvent(config, 'addToCart', newCart);
         },
         setCart:        (data : CartData) => {
-            setCartCookie('set', data);
-            return trackCartEvent(config, 'setCart', data);
+            const newCart = composeCart('set', data);
+
+            return trackCartEvent(config, 'setCart', newCart);
         },
         removeFromCart: (data : RemoveCartData) => trackCartEvent(config, 'removeFromCart', data),
         purchase:       (data : PurchaseData) => track(config, 'purchase', data),
@@ -298,44 +341,52 @@ export const Tracker = (config? : Config = defaultTrackerConfig) => {
         setPropertyId: (id : string) => {
             config.propertyId = id;
         },
-        getIdentity: (data : IdentityData, url? : string = accessTokenUrl) => {
+        getIdentity: (data : IdentityData, url? : string = accessTokenUrl) : Promise<Object> => {
             return getAccessToken(url, data.mrid)
                 .then(accessToken => {
-                  if (accessToken.data) {
-                    if(data.onIdentification) {
-                        data.onIdentification({ getAccessToken: () => accessToken.data });
+                    if (accessToken.data) {
+                        if (data.onIdentification) {
+                            data.onIdentification({ getAccessToken: () => accessToken.data });
+                        }
+                    } else {
+                        if (data.onError) {
+                            data.onError({
+                                message: 'No token could be created',
+                                error:   accessToken
+                            });
+                        }
                     }
-                  } else {
-                    if(data.onError) {
-                      data.onError({
-                        message: 'No token could be created',
-                        error: accessToken
-                      });
+                    return accessToken;
+                }).catch(err => {
+                    if (data.onError) {
+                        data.onError({
+                            message: 'No token could be created',
+                            error:   err
+                        });
                     }
-                  }
-                  return accessToken;
-                }).catch(error => {
-                    if(data.onError) {
-                      data.onError({
-                        message: 'No token could be created',
-                        error
-                      });
-                    }
+
+                    return {};
                 });
         }
     };
     const doNoop = () => {
-        // eslint-disable-next-line no-console
-        debug && isSafari && !enableSafari && console.log('PayPal Shopping: function is a noop because Safari is disabled.');
+        if (debug && isSafari && !enableSafari) {
+            // eslint-disable-next-line no-console
+            console.log('PayPal Shopping: function is a noop because Safari is disabled.');
+        }
     };
     const emptyTrackers = {
-        addToCart:  (data : CartData) => doNoop(),
-        setCart:        (data : CartData) => doNoop(),
-        removeFromCart: (data : RemoveCartData) => doNoop(),
-        purchase:       (data : PurchaseData) => doNoop(),
-        setUser:        (data : UserData) => doNoop(),
-        setPropertyId: (id : string) => doNoop(),
-        getIdentity: (data : IdentityData, url? : string = accessTokenUrl) => doNoop()
+        addToCart:      (data : CartData) => doNoop(), // eslint-disable-line no-unused-vars
+        setCart:        (data : CartData) => doNoop(), // eslint-disable-line no-unused-vars
+        removeFromCart: (data : RemoveCartData) => doNoop(), // eslint-disable-line no-unused-vars
+        purchase:       (data : PurchaseData) => doNoop(), // eslint-disable-line no-unused-vars
+        setUser:        (data : UserData) => doNoop(), // eslint-disable-line no-unused-vars
+        setPropertyId:  (id : string) => doNoop(), // eslint-disable-line no-unused-vars
+        getIdentity:    (data : IdentityData, url? : string = accessTokenUrl) : Promise<any> => { // eslint-disable-line no-unused-vars,flowtype/no-weak-types
+            return new Promise((resolve) => {
+                resolve(doNoop());
+            });
+        }
     };
     const trackerFunctions = (isSafari && !enableSafari) ? emptyTrackers : trackers;
 

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -106,15 +106,20 @@ const setRandomUserIdCookie = () : void => {
 };
 
 const composeCart = (type, data) => {
+    // Copy the data so we don't modify it outside the scope of this method.
     const _data = { ...data };
-    const storedCart = window.localStorage.getItem(storage.paypalCrCart);
+
+    // Devnote: Checking for cookie for backwards compatibility (the cookie check can be removed
+    // a couple weeks after deploy because any cart cookie storage will be moved to localStorage
+    // in this function).
+    const storedCart = window.localStorage.getItem(storage.paypalCrCart) || getCookie(storage.paypalCrCart);
     const expiry = window.localStorage.getItem(storage.paypalCrCartExpiry);
 
     if (!expiry) {
         window.localStorage.setItem(storage.paypalCrCartExpiry, Date.now() + sevenDays);
     }
 
-    if (type === 'add' && storedCart !== null) {
+    if (type === 'add' && storedCart) {
         const cart = JSON.parse(storedCart);
         const currentItems = cart && cart.items;
 

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -93,7 +93,8 @@ describe('paypal.Tracker', () => {
     afterEach(() => {
         appendChildCalls = 0;
         imgMock.src = '';
-        window.localStorage.setItem('paypal-cr-cart', '{}');
+        window.localStorage.removeItem('paypal-cr-cart');
+        document.cookie = 'paypal-cr-cart=;';
         fetchCalls = [];
     });
 
@@ -114,7 +115,7 @@ describe('paypal.Tracker', () => {
 
         window.localStorage.setItem('paypal-cr-cart-expiry', Date.now() - 10);
 
-        expect(beforeStorage).to.equal('{}');
+        expect(beforeStorage).to.equal(null);
 
         // Since the expiry is in the past, this initialization should clear
         // the cart and expiry.
@@ -125,6 +126,43 @@ describe('paypal.Tracker', () => {
 
         expect(afterStorage).to.equal(null);
         expect(afterExpiry).to.equal(null);
+    });
+
+    it('should migrate cart cookie storage to localStorage when adding an item to cart', () => {
+        const products = [
+            {
+                id:  '1',
+                url: 'example.com'
+            },
+            {
+                id:  '2',
+                url: 'example.com'
+            },
+            {
+                id:  '3',
+                url: 'example.com'
+            },
+            {
+                id:  '4',
+                url: 'example.com'
+            }
+        ];
+
+        document.cookie = `paypal-cr-cart=${ JSON.stringify({ items: [
+            products[0],
+            products[1]
+        ] }) }`;
+
+        const tracker = Tracker();
+
+        tracker.addToCart({ items: [
+            products[2],
+            products[3]
+        ] });
+
+        expect(window.localStorage.getItem('paypal-cr-cart')).equal(JSON.stringify({
+            items: products
+        }));
     });
 
     it('should send addToCart events', () => {

--- a/test/tracker-component.js
+++ b/test/tracker-component.js
@@ -93,7 +93,7 @@ describe('paypal.Tracker', () => {
     afterEach(() => {
         appendChildCalls = 0;
         imgMock.src = '';
-        document.cookie = 'paypal-cr-cart={}';
+        window.localStorage.setItem('paypal-cr-cart', '{}');
         fetchCalls = [];
     });
 
@@ -107,6 +107,24 @@ describe('paypal.Tracker', () => {
         expect(tracker).to.have.property('purchase');
         expect(tracker).to.have.property('track');
         expect(tracker).to.have.property('getIdentity');
+    });
+
+    it('should clear stored cart content if cart is expired', () => {
+        const beforeStorage = window.localStorage.getItem('paypal-cr-cart');
+
+        window.localStorage.setItem('paypal-cr-cart-expiry', Date.now() - 10);
+
+        expect(beforeStorage).to.equal('{}');
+
+        // Since the expiry is in the past, this initialization should clear
+        // the cart and expiry.
+        Tracker();
+
+        const afterStorage = window.localStorage.getItem('paypal-cr-cart');
+        const afterExpiry = window.localStorage.getItem('paypal-cr-cart-expiry');
+
+        expect(afterStorage).to.equal(null);
+        expect(afterExpiry).to.equal(null);
     });
 
     it('should send addToCart events', () => {
@@ -564,10 +582,10 @@ describe('paypal.Tracker', () => {
         };
         const url = 'https://www.paypal.com/muse/api/partner-token';
         const result = tracker.getIdentity(data, url).then(accessToken => {
-            expect(accessToken).to.be.a('string');
+            expect(result).to.be.a('promise');
+            expect(accessToken).to.be.an('object');
+            done();
         });
-        expect(result).to.be.a('promise');
-        done();
     });
 
     it('should call getIdentity function with no url passed in', done => {
@@ -580,9 +598,9 @@ describe('paypal.Tracker', () => {
             onIdentification: identityData => identityData
         };
         const result = tracker.getIdentity(data).then(accessToken => {
-            expect(accessToken).to.be.a('string');
+            expect(accessToken).to.be.an('object');
+            expect(result).to.be.a('promise');
+            done();
         });
-        expect(result).to.be.a('promise');
-        done();
     });
 });


### PR DESCRIPTION
## Problem

Currently we're using a first-party cookie to store JSON cart contents. We've encountered two problems with this:
1. One merchant's server was throwing errors when this cookie was sent to their server automatically
2. Cookies have size limits depending on the browser, so it's possible all the cart contents won't fit in the cookie.


## Solution

Use localStorage instead of a cookie. In order to maintain cookie expiration parity, I've also added a function during initialization to check an expiration value to determine if we should wipe the localStorage.

## Additional Notes

It looks like CI isn't enabled, and we don't have pre-commit hooks to run tests. When I ran tests locally, there were many flow/lint errors and two invalid test cases present. I've fixed those as well in this PR. We should activate CI and add pre-commit hooks.