### PR TITLE
Update tests

### DIFF
--- a/test/component.test.js
+++ b/test/component.test.js
@@ -29,7 +29,6 @@ describe('muse', () => {
 
         // $FlowFixMe
         it('should insert pptm.js with client ID and merchant ID', () => {
-            component.insertPptm();
             const script = document.getElementById(component.PPTM_ID);
             const expectedUrl = `id=${ window.location.hostname }&t=xo&v=${ getVersion() }&source=payments_sdk&mrid=xyz&client_id=abc`;
             const expected = expect.stringContaining(expectedUrl);

--- a/test/paypal.js
+++ b/test/paypal.js
@@ -18,3 +18,10 @@ setupSDK([
         requirer: () => muse
     }
 ]);
+
+// JSDOM initializes with the 'DOMContentLoaded' event having 
+// already been fired. We manually fire it after insterting the 
+// sdk.
+const loadEvent = document.createEvent('Event');
+loadEvent.initEvent('DOMContentLoaded', true, true);
+window.document.dispatchEvent(loadEvent);

--- a/test/tracker-component.test.js
+++ b/test/tracker-component.test.js
@@ -29,10 +29,12 @@ describe('paypal.Tracker', () => {
     };
     const propertyId = 'hello-there';
     window.fetch = (url, options) => {
+        const body = options ? options.body : undefined;
+
         fetchCalls.push([ url, options ]);
         return Promise.resolve({
             url,
-            body: options.body,
+            body,
             status: 200,
             json: () => ({ id: autoPropertyId, hello: 'hi' })
         });
@@ -731,10 +733,22 @@ describe('paypal.Tracker', () => {
         expect(appendChildCalls).toBe(1);
     });
 
+    it('should not fetch implicit propertyId route if one is not provided and propertyid is cached', () => {
+        const email = '__test__email3@gmail.com';
+        const userName = '__test__userName3';
+
+        Tracker({ user: { email, name: userName } });
+        expect(appendChildCalls).toBe(0);
+        expect(fetchCalls.length).toBe(0);
+    });
+
     it('should fetch implicit propertyId route if one is not provided', () => {
         const email = '__test__email3@gmail.com';
         const userName = '__test__userName3';
+        // clear local storage to ensure a request happens
+        window.localStorage.removeItem('property-id-abcxyz123-xyz')
         Tracker({ user: { email, name: userName } });
+
         expect(appendChildCalls).toBe(0);
         expect(fetchCalls.length).toBe(1);
         expect(fetchCalls[0][0]).toBe('https://paypal.com/tagmanager/containers/xo?mrid=xyz&url=http%3A%2F%2Flocalhost');
@@ -743,6 +757,9 @@ describe('paypal.Tracker', () => {
     it('should not fetch propertyId if one is provided', () => {
         const email = '__test__email3@gmail.com';
         const userName = '__test__userName3';
+        // clear local storage to ensure a request happens
+        window.localStorage.removeItem('property-id-abcxyz123-xyz')
+
         Tracker({ user: { email, name: userName }, propertyId: 'hello' });
         expect(fetchCalls.length).toBe(0);
     });


### PR DESCRIPTION
- A setup method in `tracker-component.test.js` was silently throwing errors, leading to a test passing when it shouldn't have.
- Manually triggers jsdom 'DOMContentLoaded' after setup.