### PR TITLE
Currency code

### DIFF
--- a/src/lib/input-validation.js
+++ b/src/lib/input-validation.js
@@ -41,7 +41,8 @@ export const validateAddItems = (input : any) => {
     const inputKeys = {
         items: [ 'array' ],
         total: [ 'string' ],
-        cartId: [ 'string', 'undefined' ]
+        cartId: [ 'string', 'undefined' ],
+        currencyCode: [ 'string', 'undefined' ]
     };
 
     const itemKeys = {
@@ -64,7 +65,8 @@ export const validateRemoveItems = (input : any) => {
     const inputKeys = {
         items: [ 'array' ],
         total: [ 'string' ],
-        cartId: [ 'string', 'undefined' ]
+        cartId: [ 'string', 'undefined' ],
+        currencyCode: [ 'string', 'undefined' ]
     };
 
     const itemKeys = {
@@ -89,7 +91,8 @@ export const validateUser = (input : any) => {
 export const validatePurchase = (input : any) => {
     const inputKeys = {
         total: [ 'string', 'undefined' ],
-        paymentProvider: [ 'string', 'undefined' ]
+        paymentProvider: [ 'string', 'undefined' ],
+        currencyCode: [ 'string', 'undefined' ]
     };
 
     checkKeys(input, inputKeys);

--- a/src/lib/input-validation.js
+++ b/src/lib/input-validation.js
@@ -52,8 +52,8 @@ export const validateAddItems = (input : any) => {
         imgUrl: [ 'string' ],
         price: [ 'string' ],
         quantity: [ 'number', 'undefined' ],
-        keywords: [ 'array', 'undefined' ],
-        otherImages: [ 'array', 'undefined' ],
+        keywords: [ 'array', 'string', 'undefined' ],
+        otherImages: [ 'array', 'string', 'undefined' ],
         description: [ 'string', 'undefined' ]
     };
 

--- a/src/lib/track.js
+++ b/src/lib/track.js
@@ -12,6 +12,8 @@ import type {
 export const track = <T>(config : Config, trackingType : TrackingType, trackingData : T) => {
     const encodeData = data => encodeURIComponent(btoa(JSON.stringify(data)));
     const cartId = getOrCreateValidCartId().cartId;
+    // $FlowFixMe
+    const currencyCode = trackingData.currencyCode || config.currencyCode;
 
     const img = document.createElement('img');
     img.style.display = 'none';
@@ -26,6 +28,7 @@ export const track = <T>(config : Config, trackingType : TrackingType, trackingD
     const deviceInfo = getDeviceInfo();
     const data = {
         ...trackingData,
+        currencyCode,
         cartId,
         user,
         propertyId: config.propertyId,

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -45,10 +45,14 @@ export type RemoveCartData = {|
     cartId? : string,
     cartTotal? : string,
     total? : string,
+    currencyCode? : string,
     items : $ReadOnlyArray<{ id : string }>
 |};
 
-export type PurchaseData = {| cartId : string |};
+export type PurchaseData = {|
+    currencyCode? : string,
+    cartId : string
+|};
 
 export type UserData = {|
     user : {|

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -97,6 +97,7 @@ export type Config = {|
         div? : string,
         lang? : string
     |},
-    paramsToPropertyIdUrl? : ParamsToPropertyIdUrl
+    paramsToPropertyIdUrl? : ParamsToPropertyIdUrl,
+    currencyCode? : string
 |};
 

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -1,7 +1,7 @@
 /* @flow */
 import 'whatwg-fetch'; // eslint-disable-line import/no-unassigned-import
 
-import { getClientID, getMerchantID } from '@paypal/sdk-client/src';
+import { getClientID, getMerchantID, getCurrency } from '@paypal/sdk-client/src';
 
 // $FlowFixMe
 import {
@@ -122,6 +122,11 @@ export const trackEvent = <T>(config : Config, trackingType : TrackingType, trac
         setCartId(trackingData.cartId);
     }
 
+    // $FlowFixMe
+    if (trackingData.currencyCode) {
+        config.currencyCode = trackingData.currencyCode;
+    }
+
     // Events cannot be fired without a propertyId. We add events
     // to a queue if a propertyId has not yet been returned.
     if (!config.propertyId) {
@@ -156,6 +161,8 @@ export const setImplicitPropertyId = (config : Config) => {
 export const Tracker = (config? : Config = {}) => {
     // $FlowFixMe
     config = { ...defaultTrackerConfig, ...config };
+    config.currencyCode = config.currencyCode || getCurrency();
+
     /*
      * Use the get param ?ppDebug=true to see logs
      *

--- a/test/tracker-component.test.js
+++ b/test/tracker-component.test.js
@@ -143,7 +143,7 @@ describe('paypal.Tracker', () => {
     it('should send addToCart events', () => {
         const email = '__test__email3@gmail.com';
         const userName = '__test__userName3';
-        const tracker = Tracker({ user: { email, name: userName } });
+        const tracker = Tracker({ currencyCode: 'FOO', user: { email, name: userName } });
         expect(appendChildCalls).toBe(0);
         tracker.setPropertyId(propertyId);
         tracker.addToCart({
@@ -158,8 +158,7 @@ describe('paypal.Tracker', () => {
                 }
             ],
             emailCampaignId: '__test__emailCampaignId',
-            cartTotal: '12345.67',
-            currencyCode: 'USD'
+            cartTotal: '12345.67'
         });
         expect(JSON.stringify(extractDataParam(imgMock.src))).toBe(
             JSON.stringify({
@@ -174,9 +173,9 @@ describe('paypal.Tracker', () => {
                     }
                 ],
                 emailCampaignId: '__test__emailCampaignId',
-                currencyCode: 'USD',
                 total: '12345.67',
                 cartEventType: 'addToCart',
+                currencyCode: 'FOO',
                 user: {
                     email: '__test__email3@gmail.com',
                     name: '__test__userName3',
@@ -312,6 +311,7 @@ describe('paypal.Tracker', () => {
         tracker.setPropertyId(propertyId);
         expect(appendChildCalls).toBe(0);
         tracker.removeFromCart({
+            currencyCode: 'LARGE_SHINY_ROCKS',
             cartId: '__test__cartId',
             cartTotal: '5.00',
             items: [
@@ -324,6 +324,7 @@ describe('paypal.Tracker', () => {
 
         expect(JSON.stringify(extractDataParam(imgMock.src))).toBe(
             JSON.stringify({
+                currencyCode: 'LARGE_SHINY_ROCKS',
                 cartId: '__test__cartId',
                 items: [ {
                     id: '__test__productId',
@@ -350,14 +351,16 @@ describe('paypal.Tracker', () => {
     it('should send purchase events', () => {
         const email = '__test__email6@gmail.com';
         const userName = '__test__userName6';
-        const tracker = Tracker({ user: { email, name: userName } });
+        const tracker = Tracker({ currencyCode: 'COWRIESHELLS', user: { email, name: userName } });
         tracker.setPropertyId(propertyId);
         expect(appendChildCalls).toBe(0);
         tracker.purchase({
+            currencyCode: 'USD',
             cartId: '__test__cartId'
         });
         expect(JSON.stringify(extractDataParam(imgMock.src))).toBe(
             JSON.stringify({
+                currencyCode: 'USD',
                 cartId: '__test__cartId',
                 user: {
                     email: '__test__email6@gmail.com',
@@ -378,13 +381,14 @@ describe('paypal.Tracker', () => {
     it('should send cancelCart events and clear localStorage upon cancelling cart', () => {
         const email = '__test__email7@gmail.com';
         const userName = '__test__userName7';
-        const tracker = Tracker({ user: { email, name: userName } });
+        const tracker = Tracker({ currencyCode: 'COWRIESHELLS', user: { email, name: userName } });
         tracker.setPropertyId(propertyId);
         expect(appendChildCalls).toBe(0);
         tracker.cancelCart({ cartId: '__test__cartId' });
         expect(JSON.stringify(extractDataParam(imgMock.src))).toBe(
             JSON.stringify({
                 cartId: '__test__cartId',
+                currencyCode: 'COWRIESHELLS',
                 user: {
                     email: '__test__email7@gmail.com',
                     name: '__test__userName7',
@@ -429,6 +433,7 @@ describe('paypal.Tracker', () => {
                     trackingType: 'purchase',
                     data: {
                         cartId: '__test__cartId',
+                        currencyCode: 'USD',
                         user: {
                             email: '__test__email@gmail.com',
                             name: '__test__userName6',
@@ -457,6 +462,7 @@ describe('paypal.Tracker', () => {
         expect(JSON.stringify(extractDataParam(imgMock.src))).toBe(
             JSON.stringify({
                 oldUserId: 'abc123',
+                currencyCode: 'USD',
                 cartId: 'abc123',
                 user: {
                     id: 'abc123',
@@ -493,6 +499,7 @@ describe('paypal.Tracker', () => {
         expect(JSON.stringify(dataParamObject)).toBe(
             JSON.stringify({
                 oldUserId: 'abc123',
+                currencyCode: 'USD',
                 cartId: 'abc123',
                 user: {
                     id: 'abc123',

--- a/test/tracker/add-to-cart.test.js
+++ b/test/tracker/add-to-cart.test.js
@@ -77,6 +77,46 @@ describe('addToCart', () => {
         expect(args[0][0].user).toEqual(config.user);
     });
 
+    it('should pass currencyCode to the track method', () => {
+        const tracker = Tracker(config);
+        const args = track.mock.calls;
+    
+        tracker.addToCart({
+            cartTotal: '25.00',
+            items: [ mockItem ]
+        });
+
+        const currencyCode1 = args[0][0].currencyCode;
+
+        tracker.addToCart({
+            currencyCode: 'DARSEK', // the darsek is the official currency of the klingon empire
+            cartTotal: '5000.00',
+            items: [ mockItem ]
+        });
+
+        const currencyCode2 = args[1][0].currencyCode;
+
+        tracker.addToCart({
+            cartTotal: '10000.00',
+            items: [ mockItem ]
+        });
+
+        const currencyCode3 = args[2][0].currencyCode;
+
+        tracker.addToCart({
+            currencyCode: 'JPY',
+            cartTotal: '5000.00',
+            items: [ mockItem ]
+        });
+
+        const currencyCode4 = args[3][0].currencyCode;
+
+        expect(currencyCode1).toBe('USD');
+        expect(currencyCode2).toBe('DARSEK');
+        expect(currencyCode3).toBe('DARSEK');
+        expect(currencyCode4).toBe('JPY');
+    });
+
     it('should enqueue events when fired before propertyId is ready', (done) => {
         const tracker = Tracker();
 
@@ -85,7 +125,7 @@ describe('addToCart', () => {
             items: [ mockItem ]
         });
         tracker.addToCart({
-            cartTotal: '25.00',
+            cartTotal: '24.00',
             items: [ mockItem ]
         });
 


### PR DESCRIPTION
- currencyCode can be passed along with any event, or at the time the 'tracker' is created.
- currencyCode defaults to that specified by client-sdk if none is specified at the time the 'tracker' is created.
- all events will now pass along currencyCode (previously they would not if the user did not explicitly pass it along with the event)
- keywords & images may now be passed as strings.