### PR TITLE
cancel cart no longer requires arguments

### DIFF
--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -37,10 +37,6 @@ export type CartData = {|
     currencyCode? : string
 |};
 
-export type CancelCartData = {|
-    cartId? : string
-|};
-
 export type RemoveCartData = {|
     cartId? : string,
     cartTotal? : string,
@@ -70,7 +66,7 @@ export type IdentityData = {|
 
 export type ParamsToBeaconUrl = ({
     trackingType : TrackingType,
-    data : ViewData | CartData | RemoveCartData | PurchaseData | CancelCartData
+    data : ViewData | CartData | RemoveCartData | PurchaseData
 }) => string;
 
 export type ParamsToTokenUrl = () => string;

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -35,7 +35,6 @@ import type {
     TrackingType,
     ViewData,
     CartData,
-    CancelCartData,
     RemoveCartData,
     PurchaseData,
     UserData,
@@ -271,8 +270,8 @@ export const Tracker = (config? : Config = {}) => {
                 console.error(err.message);
             }
         },
-        cancelCart: (data : CancelCartData) => {
-            const event = trackEvent(config, 'cancelCart', data);
+        cancelCart: () => {
+            const event = trackEvent(config, 'cancelCart', {});
             // a new id can only be created AFTER the 'cancel' event has been fired
             createNewCartId();
             return event;

--- a/test/tracker-component.test.js
+++ b/test/tracker-component.test.js
@@ -386,11 +386,11 @@ describe('paypal.Tracker', () => {
         const tracker = Tracker({ currencyCode: 'COWRIESHELLS', user: { email, name: userName } });
         tracker.setPropertyId(propertyId);
         expect(appendChildCalls).toBe(0);
-        tracker.cancelCart({ cartId: '__test__cartId' });
+        tracker.cancelCart();
         expect(JSON.stringify(extractDataParam(imgMock.src))).toBe(
             JSON.stringify({
-                cartId: '__test__cartId',
                 currencyCode: 'COWRIESHELLS',
+                cartId: 'abc123',
                 user: {
                     email: '__test__email7@gmail.com',
                     name: '__test__userName7',


### PR DESCRIPTION
- prevents a bug encountered in the paypal sdk 'cancelCart' method. (No longer requires arguments, was looking up properties of undefined.)