### PR TITLE
feat(store-user-ids): store merchant provided user ID and generated ID

### DIFF
--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -22,9 +22,9 @@ import {
     setCartId,
     createNewCartId,
     getUserId,
-    createNewUserId,
+    setGeneratedUserId,
     getOrCreateValidUserId,
-    setUserId
+    setMerchantProvidedUserId
 } from './lib/local-storage-utils';
 import { getPropertyId } from './lib/get-property-id';
 import getJetlore from './lib/jetlore';
@@ -180,16 +180,16 @@ export const Tracker = (config? : Config = {}) => {
 
     try {
         getOrCreateValidCartId();
+        getOrCreateValidUserId();
+
         if (config && config.user && config.user.id) {
-            setUserId(config.user.id);
-        } else {
-            getOrCreateValidUserId();
+            setMerchantProvidedUserId(config.user.id);
         }
     } catch (err) {
         // eslint-disable-next-line no-console
         console.error(err.message);
         createNewCartId();
-        createNewUserId();
+        setGeneratedUserId();
     }
 
     const JL = getJetlore();
@@ -289,10 +289,12 @@ export const Tracker = (config? : Config = {}) => {
                 return;
             }
 
-            if (data.id) {
-                setUserId(data.id);
-            } else if (data.id === null) {
-                createNewUserId();
+            if (data.id || data.id === null) {
+                setMerchantProvidedUserId(data.id);
+
+                if (data.id === null) {
+                    setGeneratedUserId();
+                }
             }
 
             const configUser = config.user || {};


### PR DESCRIPTION
Before this change, we were storing `paypal-cr-user = { userId: asdlkjad_sflkjsdf }` in localStorage, and the userId key would be either the user ID we generated randomly, or the merchant provided user ID.

In this PR, we'll keep that behavior, but also add the keys `generatedUserId` and `merchantProvidedUserId` to that storage so that we keep track of all three values. Note that the behavior of userId being overloaded is not changed so that we maintain compatibility with existing methods/functions w/o having to do a big refactor.

Basic logic:

1. If there is a legacy user storage, at the time of load, the SDK will set `generatedUserId = userId` and keep the existing expiry
2. If we generate a new user ID, it will set both `userId` and `generatedUserId`
3. If we call `setUser`, it will set both `userId` and `merchantProvidedUserId`
4. For both 2 and 3, a new shared `createdAt` will be set to `Date.now`

Next steps:

This PR is only concerned with maintaining these values in local storage. The next PR will be concerned with sending all of these IDs to our tracking proxy.
