### PR TITLE
fix(muse): auto pull muse component into sdk, bump to 1.1.1

### DIFF
--- a/__sdk__.js
+++ b/__sdk__.js
@@ -10,7 +10,7 @@ module.exports = {
   'muse': {
     entry: './src/index',
     staticNamespace: '__muse__',
-    automatic: false
+    automatic: true
   },
   'tracker': {
     entry: './src/tracker',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/muse-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MUSE component for unified PayPal/Braintree web sdk",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Released hotfix 1.1.1

https://www.npmjs.com/package/@paypal/muse-components/v/1.1.1
https://github.com/paypal/paypal-muse-components/releases/tag/v1.1.1

Hotfix was branched off 1.1.0: https://github.com/paypal/paypal-muse-components/tree/1.1.1-hotfix

This PR is to align those changes into the master branch as well for subsequent releases