### PR TITLE
fix(1.2.0-prerelease): pageView event keys, getContainer fixes

### DIFF
--- a/src/lib/fpti.js
+++ b/src/lib/fpti.js
@@ -39,6 +39,7 @@ const resolveTrackingData = (config : Config, data : FptiInput) : any => {
   const deviceInfo = getDeviceInfo();
 
   return {
+    product: 'ppshopping',
     e: 'im',
     comp: 'ppshoppingsdk',
     page: `ppshopping:${ data.eventName }`,
@@ -132,7 +133,15 @@ const resolveTrackingVariables = (data : any) : FptiVariables => ({
   t: data.t,
 
   // Timestamp relative to user
-  g: data.g
+  g: data.g,
+
+  external_id: data.merchantProvidedUserId,
+
+  shopper_id: data.shopperId,
+
+  merchant_cart_id: data.cartId,
+
+  product: data.product
 });
 
 export const trackFpti = (config : Config, data : FptiInput) => {

--- a/src/lib/fpti.js
+++ b/src/lib/fpti.js
@@ -18,7 +18,7 @@ export const sendBeacon = (src : string, data : FptiVariables | LegacyVariables)
 
   query = query.join('&');
 
-  const beaconImage = new window.Image();
+  const beaconImage = document.createElement('img');
   beaconImage.src = `${ src }?${ query }`;
 };
 

--- a/src/lib/get-property-id.js
+++ b/src/lib/get-property-id.js
@@ -31,20 +31,24 @@ const parseContainer = (container : Container) : ContainerSummary => {
   };
 };
 
-const getContainer = (paramsToPropertyIdUrl? : Function) : Promise<Container> => {
+const getContainer = (paramsToPropertyIdUrl? : Function) : Promise<Container> | Promise<Object> => {
   const merchantId = getMerchantID()[0];
 
-  const currentLocation = `${ window.location.protocol }//${ window.location.host }`;
-  const url = paramsToPropertyIdUrl ? paramsToPropertyIdUrl() : 'https://www.paypal.com/tagmanager/containers/xo';
+  if (merchantId) {
+    const currentLocation = `${ window.location.protocol }//${ window.location.host }`;
+    const url = paramsToPropertyIdUrl ? paramsToPropertyIdUrl() : 'https://www.paypal.com/tagmanager/containers/xo';
 
-  return fetch(`${ url }?mrid=${ merchantId }&url=${ encodeURIComponent(currentLocation) }`)
-    .then(res => {
-      if (res.status !== 200) {
-        throw new Error(`Failed to fetch propertyId: status ${ res.status }`);
-      }
+    return fetch(`${ url }?mrid=${ merchantId }&url=${ encodeURIComponent(currentLocation) }`)
+      .then(res => {
+        if (res.status !== 200) {
+          throw new Error(`Failed to fetch propertyId: status ${ res.status }`);
+        }
 
-      return res.json();
-    });
+        return res.json();
+      });
+  } else {
+    return Promise.resolve({});
+  }
 };
 
 export const fetchPropertyId = ({ paramsToPropertyIdUrl, propertyId } : Config) : Promise<string> => {

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -386,7 +386,9 @@ export const Tracker = (config? : Config = {}) => {
         }
       };
 
-      trackEvent(config, 'setUser', { prevMerchantProvidedUserId });
+      if (merchantProvidedUserId !== undefined) {
+        trackEvent(config, 'setUser', { prevMerchantProvidedUserId });
+      }
     },
     setPropertyId: (id : string) => {
       config.propertyId = id;

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -386,7 +386,7 @@ export const Tracker = (config? : Config = {}) => {
         }
       };
 
-      if (merchantProvidedUserId !== undefined) {
+      if (merchantProvidedUserId !== undefined || userEmail || userName) {
         trackEvent(config, 'setUser', { prevMerchantProvidedUserId });
       }
     },

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -23,7 +23,8 @@ import {
   getUserId,
   setGeneratedUserId,
   getOrCreateValidUserId,
-  setMerchantProvidedUserId
+  setMerchantProvidedUserId,
+  getCartId
 } from './lib/local-storage';
 import { fetchContainerSettings } from './lib/get-property-id';
 import {
@@ -236,6 +237,20 @@ export const Tracker = (config? : Config = {}) => {
   config.user.id = userId;
   config.currencyCode = config.currencyCode || getCurrency();
 
+  /*
+    Quick devnote here:
+
+    If a merchant doesn't provide a user ID during initialization or call setUser,
+    then any previously-stored merchant provided user ID will *not* be pulled into
+    config.user.merchantProvidedUserId.
+
+    This differs in behavior from the SDK generated user ID ("shopper ID"). The shopper ID
+    will be created, stored in storage, and set in config.user.id, or if it already exists
+    in local storage, then it will be pulled into config.user.id.
+
+    The difference in behavior is intended.
+  */
+
   const JL = getJetlore();
   const jetloreTrackTypes = [
     'view',
@@ -276,9 +291,19 @@ export const Tracker = (config? : Config = {}) => {
       return config;
     },
     viewPage: () => {
+      // $FlowFixMe
+      const merchantProvidedUserId = getUserId().merchantProvidedUserId;
+      // $FlowFixMe
+      const shopperId = getUserId().userId;
+      // $FlowFixMe
+      const cartId = getCartId().cartId;
+
       const data : FptiInput = {
         eventName: 'pageView',
-        eventType: 'view'
+        eventType: 'view',
+        shopperId,
+        merchantProvidedUserId,
+        cartId
       };
 
       trackEvent(config, 'view', data);

--- a/src/types/fpti.js
+++ b/src/types/fpti.js
@@ -47,7 +47,13 @@ export type FptiInput = {|
   // Timestamp
   t? : ?Date,
   // Timestamp relative to user
-  g? : ?Date
+  g? : ?Date,
+  // Cart ID
+  cartId? : string,
+  // SDK generated user ID
+  shopperId? : string,
+  // Merchant provided user ID
+  merchantProvidedUserId? : string
 |};
 
 export type FptiVariables = {|
@@ -104,7 +110,16 @@ export type FptiVariables = {|
   // Timestamp
   t : Date,
   // Timestamp relative to user
-  g : Date
+  g : Date,
+  // Cart ID
+  merchant_cart_id : string,
+  // SDK generated user ID
+  shopper_id : string,
+  // Merchant provided user ID
+  external_id : string,
+
+  // Constant: ppshopping (switchboard filter)
+  product : string
 |};
 
 /* Workaround for the sake of supporting legacy analytics implementation.

--- a/test/tracker-component.test.js
+++ b/test/tracker-component.test.js
@@ -22,6 +22,12 @@ const extractDataParam = (url : string) : string => {
   );
 };
 
+const queryToObject = (src : string) => {
+  const search = src.split('?')[1];
+
+  return JSON.parse(`{"${ decodeURI(search).replace(/"/g, '\\"').replace(/&/g, '","').replace(new RegExp('=', 'g'), '":"') }"}`);
+};
+
 const autoPropertyId = 'wow-so-auto';
 let fetchCalls = [];
 
@@ -751,5 +757,40 @@ describe('paypal.Tracker', () => {
     expect(logger.error.mock.calls.length).toBe(2);
     expect(typeof userId).toBe('string');
     expect(typeof cartId).toBe('string');
+  });
+
+  describe('#viewPage', () => {
+    it('should fire a well-formed page view event', () => {
+      const tracker = Tracker();
+      tracker.setPropertyId(propertyId);
+
+      tracker.viewPage();
+
+      expect(queryToObject(imgMock.src)).toEqual(
+        expect.objectContaining(
+          {
+            bh: '400',
+            bw: '400',
+            cd: '300',
+            sh: '750',
+            sw: '1000',
+            dvis: 'desktop',
+            item: 'hello-there',
+            mrid: 'xyz',
+            client_id: 'abcxyz123',
+            event_name: 'pageView',
+            event_type: 'view',
+            page: 'ppshopping%3ApageView',
+            pgrp: 'ppshopping%3ApageView',
+            comp: 'ppshoppingsdk',
+            e: 'im',
+            g: '420',
+            shopper_id: 'abc123',
+            merchant_cart_id: 'abc123',
+            product: 'ppshopping'
+          }
+        )
+      );
+    });
   });
 });

--- a/test/tracker-component.test.js
+++ b/test/tracker-component.test.js
@@ -784,7 +784,6 @@ describe('paypal.Tracker', () => {
             pgrp: 'ppshopping%3ApageView',
             comp: 'ppshoppingsdk',
             e: 'im',
-            g: '420',
             shopper_id: 'abc123',
             merchant_cart_id: 'abc123',
             product: 'ppshopping'


### PR DESCRIPTION
Re: 1.2.0 pre release QA testing

1. Adds external_id, shopper_id, merchant_cart_id, and product=ppshopping to page view events
2. Adds devnote about merchant provided user ID not being populated in config when it pre-exists in local storage
3. Only requests a container if merchant ID is present (in the future, we need to support querying a container by client ID as well)
4. Don't fire setUser call if no changes were made to merchant provided user info