### PR TITLE
fix(get-container): return empty container if no merchant-id param

### DIFF
--- a/src/lib/get-property-id.js
+++ b/src/lib/get-property-id.js
@@ -31,7 +31,14 @@ const parseContainer = (container : Container) : ContainerSummary => {
   };
 };
 
-const getContainer = (paramsToPropertyIdUrl? : Function) : Promise<Container> | Promise<Object> => {
+const emptyContainer : Container = {
+  id: '',
+  integration_type: '',
+  owner_id: '',
+  tags: []
+};
+
+const getContainer = (paramsToPropertyIdUrl? : Function) : Promise<Container> => {
   const merchantId = getMerchantID()[0];
 
   if (merchantId) {
@@ -47,7 +54,7 @@ const getContainer = (paramsToPropertyIdUrl? : Function) : Promise<Container> | 
         return res.json();
       });
   } else {
-    return Promise.resolve({});
+    return Promise.resolve(emptyContainer);
   }
 };
 

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -497,11 +497,22 @@ export const Tracker = (config? : Config = {}) => {
 
   trackerFunctions.viewPage();
 
-  return {
+  const fullTracker = {
     // bringing in tracking functions for backwards compatibility
     ...trackerFunctions,
     track: trackEventByType,
     identify,
     getJetlorePayload
   };
+
+  // Adding tracker onto the window so that we can inspect its properties
+  // for debugging. For example, window.__pp__trackers__[0].getConfig()
+  // will show all the config properties. It's an array in case for whatever
+  // reason a merchant website instantiates multiple trackers (then that's
+  // good for us to know too).
+  window.__pp__trackers__ = window.__pp__trackers__ || [];
+
+  window.__pp__trackers__.push(fullTracker);
+
+  return fullTracker;
 };


### PR DESCRIPTION
We noticed a console error on PPDG after the v1.2.0 deploy:

```
{err: "TypeError: Cannot read property 'filter' of undefi…currency=USD&components=buttons,tracker:1:276395)", timestamp: "1572546347180", referer: "www.paypal.com", uid: "21863db048_mtg6mjq6mzg", env: "production"}
env: "production"
err: "TypeError: Cannot read property 'filter' of undefined↵    at dc (https://www.paypal.com/sdk/js?client-id=ATFYkSwsTBKvKegx5PbKw_hsQVZWAWWwJU5WqcwjdaCeHchv30PL90wFhe3xqzsT2Fd5xp9aVXp874Cu&currency=USD&components=buttons,tracker:1:276395)"
referer: "www.paypal.com"
timestamp: "1572546347180"
uid: "21863db048_mtg6mjq6mzg"
__proto__: Object
```

If no merchant-id is passed in, we return an empty object from `getContainer`. It's because I changed the signature of getContainer to return `Promise<Container> | Promise<Object>`, so functions that depend on it returning a Container type fail. There was no effect on PPDG (other than showing an error), because PPDG sets the property ID manually.

This PR addresses that bug, as well as adds tracker components to the window to aid in debugging.