### PR TITLE
Fix error being thrown for setCart and addCart

### DIFF
--- a/src/lib/validation/limit-cart-items.js
+++ b/src/lib/validation/limit-cart-items.js
@@ -1,6 +1,5 @@
 /* @flow */
 import constants from '../constants';
-import { logger } from '../logger';
 
 export const limitCartItems = (input : any)  => {
   const { cartLimit } = constants;

--- a/src/lib/validation/limit-cart-items.js
+++ b/src/lib/validation/limit-cart-items.js
@@ -5,7 +5,6 @@ import { logger } from '../logger';
 export const limitCartItems = (input : any)  => {
   const { cartLimit } = constants;
   if (input.items && input.items.length > cartLimit) {
-    logger.error(`Total number of items in cart is greater than ${ cartLimit }, cart will be truncated`);
     input.items = input.items.splice(0, cartLimit);
   }
   return input;


### PR DESCRIPTION
Removed logger.error because we do not want to throw an error when truncating the cart (if there are more than 10 products). The expected behavior is for the tracker calls to still go through after limiting the cart payload 