### PR TITLE
2.5/3 JL functions from SDK

### DIFF
--- a/src/lib/jetlore.js
+++ b/src/lib/jetlore.js
@@ -100,6 +100,7 @@ const initializeJL = (config = {}) => {
 
   JL = {
     trackActivity(type, data) : null {
+      console.log(type, data);
       if (!jlEnabled || !trackTypes.includes(type)) {
         return null;
       }

--- a/src/lib/jetlore.js
+++ b/src/lib/jetlore.js
@@ -100,7 +100,6 @@ const initializeJL = (config = {}) => {
 
   JL = {
     trackActivity(type, data) : null {
-      console.log(type, data);
       if (!jlEnabled || !trackTypes.includes(type)) {
         return null;
       }

--- a/src/tracker-component.js
+++ b/src/tracker-component.js
@@ -205,6 +205,10 @@ export const Tracker = (config? : Config = {}) => {
     The difference in behavior is intended.
   */
 
+  // Initialize JL Module. Note: getJetlore must never throw an error
+  // Which is why getJetlore is wrapped around a try catch
+  const JL = getJetlore(config);
+
   const trackers = {
     getConfig: () => {
       return config;
@@ -239,6 +243,7 @@ export const Tracker = (config? : Config = {}) => {
     setCart: (data : CartData) => {
       try {
         data = setCartNormalizer(data);
+        JL.trackActivity('setCart', data);
         validateAddItems(data);
         return trackCartEvent(config, 'setCart', data);
       } catch (err) {
@@ -360,10 +365,6 @@ export const Tracker = (config? : Config = {}) => {
     }
   };
   setImplicitPropertyId(config);
-
-  // Initialize JL Module. Note: getJetlore must never throw an error
-  // Which is why getJetlore is wrapped around a try catch
-  const JL = getJetlore(config);
 
   try {
     // This will add JL specific functions to trackers object

--- a/test/tracker-component.test.js
+++ b/test/tracker-component.test.js
@@ -2,6 +2,7 @@
 /* @flow */
 import { Tracker } from '../src/tracker-component';
 import { logger } from '../src/lib/logger';
+import getJetlore from '../src/lib/jetlore';
 import constants from '../src/lib/constants';
 // $FlowFixMe
 import generateIdModule from '../src/lib/generate-id';
@@ -276,7 +277,10 @@ describe('paypal.Tracker', () => {
   it('should send setCart events', () => {
     const email = '__test__email4@gmail.com';
     const userName = '__test__userName4';
-    const tracker = Tracker({ user: { email, name: userName } });
+    const tracker = Tracker({ user: { email, name: userName }, jetlore: { access_token: '1234' } });
+    const JL = getJetlore();
+    JL.trackActivity = jest.fn();
+
     tracker.setPropertyId(propertyId);
     expect(createElementCalls).toBe(2);
     tracker.addToCart({
@@ -339,6 +343,23 @@ describe('paypal.Tracker', () => {
       })
     );
     expect(createElementCalls).toBe(4);
+    expect(JL.trackActivity.mock.calls.length).toEqual(1);
+    expect(JL.trackActivity.mock.calls[0][0]).toEqual('setCart');
+    expect(JL.trackActivity.mock.calls[0][1]).toEqual({
+      cartId: '__test__cartId',
+      items: [
+        {
+          title: 'william of normandy',
+          imgUrl: 'animageurl',
+          price: 'tree fiddy',
+          id: '__test__productId',
+          url: 'https://example.com/__test__productId'
+        }
+      ],
+      emailCampaignId: '__test__emailCampaignId',
+      currencyCode: 'USD',
+      total: '12345.67'
+    });
   });
 
 


### PR DESCRIPTION
The only function from the SDK that JL needs is the `setCart` function. This PR makes sure the JL functionality is called when `setCart` is called.