### PR TITLE
Add support for passing components, vault sdk query param to pptm.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/muse-components",
-  "version": "1.3.13",
+  "version": "1.3.16",
   "description": "MUSE component for unified PayPal/Braintree web sdk",
   "main": "index.js",
   "scripts": {

--- a/src/component.js
+++ b/src/component.js
@@ -35,18 +35,20 @@ export function getPptmScriptSrc(paypalDomain : string, mrid : ?string, clientId
   }
 
   /*
-   * Add a subtype of checkout, based on query params passed to the sdk.
-   * st - subtype
-   * Examples:
-   *   ucc (unbranded credit card) - /sdk/js?components=hosted-fields,buttons (src: https://developer.paypal.com/docs/business/checkout/advanced-card-payments/)
-   *   subscription - /sdk/js?vault=true (src: https://developer.paypal.com/docs/business/subscriptions/)
+    Add components query param passed to sdk
+    Documentation - https://developer.paypal.com/docs/checkout/reference/customize-sdk/#components
+    sample values (comma separated) - hosted-fields, buttons, marks, messages
   */
-  const componentsQuery = getSDKQueryParam('components');
-  if (componentsQuery && componentsQuery.includes('hosted-fields')) {
-    src += `&st=ucc`;
-  } else if (getVault()) {
-    src += `&st=subscription`;
+  if (getSDKQueryParam('components')) {
+    src += `&comp=${ String(getSDKQueryParam('components')) }`;
   }
+  
+  /*
+    Add the vault query passed to sdk
+    Documentation - https://developer.paypal.com/docs/checkout/reference/customize-sdk/#vault
+  */
+  src += `&vault=${ String(getVault()) }`;
+  
   
   return src;
 }

--- a/src/component.js
+++ b/src/component.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { getClientID, getMerchantID, getPayPalDomain, getVersion, isPayPalDomain, getEventEmitter, getDebug, getEnv } from '@paypal/sdk-client/src';
+import { getClientID, getMerchantID, getPayPalDomain, getVersion, isPayPalDomain, getEventEmitter, getDebug, getEnv, getVault, getSDKQueryParam } from '@paypal/sdk-client/src';
 import { UNKNOWN, ENV } from '@paypal/sdk-constants/src';
 
 import { logger } from './lib/logger';
@@ -34,6 +34,20 @@ export function getPptmScriptSrc(paypalDomain : string, mrid : ?string, clientId
     src += `&client_id=${ clientId }`;
   }
 
+  /*
+   * Add a subtype of checkout, based on query params passed to the sdk.
+   * st - subtype
+   * Examples:
+   *   ucc (unbranded credit card) - /sdk/js?components=hosted-fields,buttons (src: https://developer.paypal.com/docs/business/checkout/advanced-card-payments/)
+   *   subscription - /sdk/js?vault=true (src: https://developer.paypal.com/docs/business/subscriptions/)
+  */
+  const componentsQuery = getSDKQueryParam('components');
+  if (componentsQuery && componentsQuery.includes('hosted-fields')) {
+    src += `&st=ucc`;
+  } else if (getVault()) {
+    src += `&st=subscription`;
+  }
+  
   return src;
 }
 


### PR DESCRIPTION
Release: 1.3.16

Background: 
As part of automating ppcp setup cards, we want to track more granular details of the checkout code that's copied by merchants. This PR passes the `components` & `vault` sdk query params to pptm.js as `comp` & vault` respectively. 

for more info: 
1. [vault query param](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#vault) - Used in subscriptions here https://developer.paypal.com/docs/business/subscriptions/


2. [components query param](https://developer.paypal.com/docs/checkout/reference/customize-sdk/#components ) -  Used in unbranded credit/debit card checkout integration here https://developer.paypal.com/docs/business/checkout/advanced-card-payments/