### PR TITLE
JS SDK async loading fix when using muse-components

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-registry=http://registry.npmjs.org/
+registry=https://registry.npmjs.org/
 save=false
 package-lock=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-registry=http://registry.npmjs.com/
+registry=http://registry.npmjs.org/
 save=false
 package-lock=false

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@paypal/sdk-client": "^4.0.1",
+    "belter": "^1.0.141",
     "whatwg-fetch": "^3.0.0"
   },
   "jest": {

--- a/src/component.js
+++ b/src/component.js
@@ -1,37 +1,55 @@
 /* @flow */
 
-import { getClientID, getMerchantID, getPayPalDomain, getVersion, isPayPalDomain, getEventEmitter, getDebug, getEnv, getVault, getSDKQueryParam } from '@paypal/sdk-client/src';
-import { UNKNOWN, ENV } from '@paypal/sdk-constants/src';
+import {
+  getClientID,
+  getMerchantID,
+  getPayPalDomain,
+  getVersion,
+  isPayPalDomain,
+  getEventEmitter,
+  getDebug,
+  getEnv,
+  getVault,
+  getSDKQueryParam,
+} from "@paypal/sdk-client/src";
+import { UNKNOWN, ENV } from "@paypal/sdk-constants/src";
 
-import { logger } from './lib/logger';
+import { logger } from "./lib/logger";
 
-export const PPTM_ID = 'xo-pptm';
+import { waitForWindowReady } from "belter/dist/module";
+
+export const PPTM_ID = "xo-pptm";
 
 /*
 Generates a URL for pptm.js, e.g. http://localhost:8001/tagmanager/pptm.js?id=www.merchant-site.com&t=xo&mrid=xyz&client_id=abc
 */
-export function getPptmScriptSrc(paypalDomain : string, mrid : ?string, clientId : ?string, url : string) : string {
+export function getPptmScriptSrc(
+  paypalDomain: string,
+  mrid: ?string,
+  clientId: ?string,
+  url: string
+): string {
   // "xo" is a checkout container
-  const type = 'xo';
+  const type = "xo";
 
   // We send this so that we know what version of the Payments SDK the request originated from.
   const version = getVersion();
 
-  const source = 'payments_sdk';
+  const source = "payments_sdk";
 
-  const baseUrl = `${ paypalDomain }/tagmanager/pptm.js`;
+  const baseUrl = `${paypalDomain}/tagmanager/pptm.js`;
 
-  let src = `${ baseUrl }?id=${ url }&t=${ type }&v=${ version }&source=${ source }`;
+  let src = `${baseUrl}?id=${url}&t=${type}&v=${version}&source=${source}`;
 
   // Optional in the payments SDK, but if it's here, we'll prefer
   // to query pptm.js by the mrid.
   if (mrid) {
-    src += `&mrid=${ mrid }`;
+    src += `&mrid=${mrid}`;
   }
 
   // Technically, this is required by the Payments SDK
   if (clientId) {
-    src += `&client_id=${ clientId }`;
+    src += `&client_id=${clientId}`;
   }
 
   /*
@@ -39,21 +57,20 @@ export function getPptmScriptSrc(paypalDomain : string, mrid : ?string, clientId
     Documentation - https://developer.paypal.com/docs/checkout/reference/customize-sdk/#components
     sample values (comma separated) - hosted-fields, buttons, marks, messages
   */
-  if (getSDKQueryParam('components')) {
-    src += `&comp=${ String(getSDKQueryParam('components')) }`;
+  if (getSDKQueryParam("components")) {
+    src += `&comp=${String(getSDKQueryParam("components"))}`;
   }
-  
+
   /*
     Add the vault query passed to sdk
     Documentation - https://developer.paypal.com/docs/checkout/reference/customize-sdk/#vault
   */
-  src += `&vault=${ String(getVault()) }`;
-  
-  
+  src += `&vault=${String(getVault())}`;
+
   return src;
 }
 
-function parseMerchantId() : ?string {
+function parseMerchantId(): ?string {
   const merchantId = getMerchantID();
 
   if (!merchantId.length || merchantId[0] === UNKNOWN) {
@@ -63,13 +80,16 @@ function parseMerchantId() : ?string {
   return merchantId[0];
 }
 
-function _isPayPalDomain() : boolean {
-  return window.mockDomain === 'mock://www.paypal.com' || isPayPalDomain();
+function _isPayPalDomain(): boolean {
+  return window.mockDomain === "mock://www.paypal.com" || isPayPalDomain();
 }
 
 // Inserts the pptm.js script tag. This is the `setupHandler` in __sdk__.js and will be called automatically
 // when the made SDK is initialized.
-export function insertPptm(env : string = getEnv(), isDebug : boolean = getDebug()) {
+export function insertPptm(
+  env: string = getEnv(),
+  isDebug: boolean = getDebug()
+) {
   try {
     // When merchants use checkout buttons, they'll include the payments SDK on their
     // website, and then it'll render an iframe from the PayPal domain which will in turn
@@ -89,8 +109,8 @@ export function insertPptm(env : string = getEnv(), isDebug : boolean = getDebug
       const clientId = getClientID();
       const url = window.location.hostname;
       const paypalDomain = getPayPalDomain();
-      const script = document.createElement('script');
-      const head = document.querySelector('head');
+      const script = document.createElement("script");
+      const head = document.querySelector("head");
 
       const src = getPptmScriptSrc(paypalDomain, mrid, clientId, url);
 
@@ -105,22 +125,24 @@ export function insertPptm(env : string = getEnv(), isDebug : boolean = getDebug
       }
     }
   } catch (err) {
-    logger.error('insertPPTM', err);
+    logger.error("insertPPTM", err);
   }
 }
 
 function listenForButtonRender() {
-  getEventEmitter().on('button_render', () => {
+  getEventEmitter().on("button_render", () => {
     window.paypalDDL = window.paypalDDL || [];
-    const buttonRenderEvent = window.paypalDDL.filter(e => e.event === 'paypalButtonRender');
+    const buttonRenderEvent = window.paypalDDL.filter(
+      (e) => e.event === "paypalButtonRender"
+    );
     if (buttonRenderEvent.length === 0) {
-      window.paypalDDL.push({ event: 'paypalButtonRender' });
+      window.paypalDDL.push({ event: "paypalButtonRender" });
     }
   });
 }
 
 export function setup() {
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener("DOMContentLoaded", () => {
     insertPptm(getEnv(), getDebug());
   });
   listenForButtonRender();

--- a/src/component.js
+++ b/src/component.js
@@ -142,8 +142,6 @@ function listenForButtonRender() {
 }
 
 export function setup() {
-  document.addEventListener("DOMContentLoaded", () => {
-    insertPptm(getEnv(), getDebug());
-  });
+  waitForWindowReady().then(() => insertPptm(getEnv(), getDebug()));
   listenForButtonRender();
 }


### PR DESCRIPTION
Added belter to paypal-muse-components and used the waitForWindowReady() function instead of the DOMContentLoaded event in the setup() hook to eliminate the current race condition that had been resulting in the JS SDK failing to load async when using muse-components.