### PR TITLE
*New* JS SDK async loading fix when using muse-components

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-registry=http://registry.npmjs.com/
+registry=https://registry.npmjs.org/
 save=false
 package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-   - "8"
+   - "lts/*"
 before_script:
   - npm run flow-typed
 script: npm run test

--- a/src/component.js
+++ b/src/component.js
@@ -120,8 +120,6 @@ function listenForButtonRender() {
 }
 
 export function setup() {
-  document.addEventListener('DOMContentLoaded', () => {
-    insertPptm(getEnv(), getDebug());
-  });
+  insertPptm(getEnv(), getDebug());
   listenForButtonRender();
 }


### PR DESCRIPTION
Removed the DOMContentLoaded event listener in the setup() hook to eliminate the current race condition that had been resulting in the JS SDK failing to load async when using muse-components.