### PR TITLE
Implement generic event send() method

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/src/lib/shopping-analytics.js
+++ b/src/lib/shopping-analytics.js
@@ -1,9 +1,13 @@
 /* @flow */
 import type { FptiInput, Config } from '../types';
+import type { EventType } from '../types/shopping-events';
 
 import autoGenerateProductPayload from './utils';
 import { ShoppingEventPublisher } from './shopping-fpti-event-publisher';
-import { eventToFptiConverters, type EventToFptiInputMapping } from './shopping-event-conversions';
+import {
+  eventToFptiConverters,
+  type EventToFptiInputMapping
+} from './shopping-event-conversions';
 import { setUser } from './user-configuration';
 
 const initEventPublisher = (config : Config) => {
@@ -15,6 +19,17 @@ const initEventPublisher = (config : Config) => {
     };
   };
 };
+
+function initGenericEventPublisher(config : Config) : Object {
+  const fptiEventPubisher = ShoppingEventPublisher(config);
+  const convertEvent = eventToFptiConverters(config).eventToFpti;
+  return {
+    publishEvent: (event : EventType, payload : Object) => {
+      const fptiInput : FptiInput = convertEvent(event, payload);
+      fptiEventPubisher.publishFptiEvent(fptiInput);
+    }
+  };
+}
 
 /**
  * Setup the various trackers which are a part of the shopping analytics
@@ -34,9 +49,8 @@ const initEventPublisher = (config : Config) => {
 export const setupTrackers = (config : Config) => {
   const eventPublisher = initEventPublisher(config);
   const converters = eventToFptiConverters(config);
-
   const viewPage = eventPublisher(converters.viewPageToFpti);
   const viewProduct = eventPublisher(converters.viewProductToFpti);
-
-  return { viewPage, viewProduct, setUser, autoGenerateProductPayload };
+  const send = initGenericEventPublisher(config).publishEvent;
+  return { viewPage, viewProduct, send, setUser, autoGenerateProductPayload };
 };

--- a/src/lib/shopping-event-conversions.js
+++ b/src/lib/shopping-event-conversions.js
@@ -27,6 +27,7 @@ function convertShoppingEventToFptiInput(
   event : Object,
   eventType : EventType
 ) : FptiInput {
+
   if (!event.user) {
     event.user = config.user;
   }
@@ -54,6 +55,9 @@ export const eventToFptiConverters = (config : Config) => {
         ? viewData.currency
         : config.currencyCode;
       return convertShoppingEventToFptiInput(config, viewData, 'productView');
+    },
+    eventToFpti: (event : EventType, payload : Object) : FptiInput => {
+      return convertShoppingEventToFptiInput(config, payload, event);
     }
   };
 };

--- a/src/lib/shopping-fpti-event-publisher.js
+++ b/src/lib/shopping-fpti-event-publisher.js
@@ -25,11 +25,12 @@ export const ShoppingEventPublisher = (config : Config) => {
    * @returns {boolean}
    */
   function isAllowedToPublishEvent() : boolean {
-    const isContainerIdSet =
-      config.propertyId !== undefined &&
-      config.propertyId !== null &&
-      config.propertyId.length > 0;
-    return isContainerIdSet;
+    // const isContainerIdSet =
+    //   config.propertyId !== undefined &&
+    //   config.propertyId !== null &&
+    //   config.propertyId.length > 0;
+    // return isContainerIdSet;
+    return true;
   }
 
   /**

--- a/src/types/shopping-events.js
+++ b/src/types/shopping-events.js
@@ -1,30 +1,21 @@
 /* @flow */
 
-import type { UserData  } from './user';
-
 export type EventType = 'pageView' | 'productView' | 'purchase' | 'setUser' | 'cancelCart' | 'customEvent';
-export type PageType = 'HOME_PAGE' | 'CATEGORY' | 'SEARCH_RESULTS' | 'DEALS' | 'CART' | 'CHECKOUT' | 'ORDER_CONFIRMATION';
-
-export type Category = {|
-    id : string,
-    name? : string
-|};
 
 export type PageView = {|
     id? : string,
-    page_type? : PageType,
+    page_type? : string,
     name? : string,
-    category? : Category,
-    user? : UserData
+    category? : string
 |};
 
 export type ProductView = {|
-    product_id : string, // the product id or SKU
+    product_id : string, // the product id
+    sku_id? : string, // SKU Id
     product_name? : string,
-    category? : Category,
+    category? : string,
     price? : string, // eg 200.00
     currency? : string, // ISO code
     url? : string,
-    brand? : string, // product brand
-    user? : UserData
+    brand? : string // product brand
 |};

--- a/test/lib/shopping-analytics.test.js
+++ b/test/lib/shopping-analytics.test.js
@@ -30,6 +30,7 @@ jest.mock('../../src/lib/shopping-event-conversions');
 
 const viewPageToFptiMock = jest.fn();
 const viewProductToFptiMock = jest.fn();
+const eventToFptiMock = jest.fn();
 const fptiPublishMock = jest.fn();
 
 describe('test eventTracker setup', () => {
@@ -37,7 +38,8 @@ describe('test eventTracker setup', () => {
     eventToFptiConverters.mockClear();
     eventToFptiConverters.mockReturnValue({
       viewPageToFpti: viewPageToFptiMock,
-      viewProductToFpti: viewProductToFptiMock
+      viewProductToFpti: viewProductToFptiMock,
+      eventToFpti: eventToFptiMock
     });
 
     ShoppingEventPublisher.mockClear();
@@ -48,6 +50,9 @@ describe('test eventTracker setup', () => {
 
     viewProductToFptiMock.mockClear();
     viewProductToFptiMock.mockReturnValue(mockFptiInput);
+
+    eventToFptiMock.mockClear();
+    eventToFptiMock.mockReturnValue(mockFptiInput);
 
   });
   
@@ -62,6 +67,13 @@ describe('test eventTracker setup', () => {
     const trackers = setupTrackers(config);
     trackers.viewProduct(productView);
     expect(viewProductToFptiMock).toBeCalledWith(productView);
+    expect(fptiPublishMock).toBeCalledWith(mockFptiInput);
+  });
+
+  it('should send() handle generic events', () => {
+    const trackers = setupTrackers(config);
+    trackers.send('testEvent', productView);
+    expect(eventToFptiMock).toBeCalledWith('testEvent', productView);
     expect(fptiPublishMock).toBeCalledWith(mockFptiInput);
   });
 

--- a/test/lib/shopping-event-conversions.test.js
+++ b/test/lib/shopping-event-conversions.test.js
@@ -69,4 +69,13 @@ describe('test event converters to FPTI input', () => {
     expect(fptiEvent.shopperId).toEqual(generatedUserId);
     expect(fptiEvent.merchantProvidedUserId).toEqual(merchantProvidedUserId);
   });
+
+  it('should map generic event to FPTI input', () => {
+    const fptiEvent = eventConverters.eventToFpti('productView', productView);
+    expect(fptiEvent.eventName).toEqual('productView');
+    expect(fptiEvent.eventType).toEqual('productView');
+    expect(fptiEvent.eventData).toEqual(JSON.stringify(productView));
+    expect(fptiEvent.shopperId).toEqual(generatedUserId);
+    expect(fptiEvent.merchantProvidedUserId).toEqual(merchantProvidedUserId);
+  });
 });

--- a/test/lib/shopping-fpti-event-publisher.test.js
+++ b/test/lib/shopping-fpti-event-publisher.test.js
@@ -1,6 +1,7 @@
 /* global expect jest */
 /* @flow */
-import { v4 as uuidv4 } from 'uuid';
+
+// import { v4 as uuidv4 } from 'uuid';
 
 import { trackFptiV2 } from '../../src/lib/fpti';
 import { ShoppingEventPublisher } from '../../src/lib/shopping-fpti-event-publisher';
@@ -23,10 +24,10 @@ const containerSummary = {
 jest.mock('../../src/lib/fpti');
 jest.mock('../../src/lib/get-property-id');
 
-const generateRandomFPTIInput = () => {
-  const event = { ...fptiInput };
-  event.eventData = `{"id":  "${ uuidv4() }"}`;
-};
+// const generateRandomFPTIInput = () => {
+//   const event = { ...fptiInput };
+//   event.eventData = `{"id":  "${ uuidv4() }"}`;
+// };
 
 describe('test ShoppingEventPublisher publish fpti events', () => {
   beforeEach(() => {
@@ -77,27 +78,29 @@ describe('test ShoppingEventPublisher publish fpti events', () => {
     setTimeout(() => expect(trackFptiV2).toHaveBeenCalledTimes(0), 1000);
   });
 
-  it('should enqueue message if container is missing', () => {
-    const config = {};
-    fetchContainerSettings.mockReturnValue(Promise.resolve({}));
-    const publisher = ShoppingEventPublisher(config);
-    publisher.publishFptiEvent(fptiInput);
-    const queue = publisher.getFptiEventsQueue();
-    expect(queue).toEqual([ fptiInput ]);
-    setTimeout(() => expect(trackFptiV2).toHaveBeenCalledTimes(0), 1000);
-  });
+  // temporarily disable container check, until look up by client is is added.
+  
+  // it('should enqueue message if container is missing', () => {
+  //   const config = {};
+  //   fetchContainerSettings.mockReturnValue(Promise.resolve({}));
+  //   const publisher = ShoppingEventPublisher(config);
+  //   publisher.publishFptiEvent(fptiInput);
+  //   const queue = publisher.getFptiEventsQueue();
+  //   expect(queue).toEqual([ fptiInput ]);
+  //   setTimeout(() => expect(trackFptiV2).toHaveBeenCalledTimes(0), 1000);
+  // });
 
-  it('should have limit of 100 events to enqueue', () => {
-    const config = {};
-    fetchContainerSettings.mockReturnValue(Promise.resolve({}));
-    const publisher = ShoppingEventPublisher(config);
+  // it('should have limit of 100 events to enqueue', () => {
+  //   const config = {};
+  //   fetchContainerSettings.mockReturnValue(Promise.resolve({}));
+  //   const publisher = ShoppingEventPublisher(config);
     
-    for (let i = 0; i < 150; i++) {
-      const fptiEvent = generateRandomFPTIInput();
-      publisher.publishFptiEvent(fptiEvent);
-    }
+  //   for (let i = 0; i < 150; i++) {
+  //     const fptiEvent = generateRandomFPTIInput();
+  //     publisher.publishFptiEvent(fptiEvent);
+  //   }
     
-    const queue = publisher.getFptiEventsQueue();
-    expect(queue.length).toEqual(100);
-  });
+  //   const queue = publisher.getFptiEventsQueue();
+  //   expect(queue.length).toEqual(100);
+  // });
 });


### PR DESCRIPTION
- Update ShoppingAnalytics with new method to publish events. It should take an event name and payload. 
- Disable container verification for integrating with SDK until the lookup by client id is added
- loosen up the structure of the existing events. 
