### PR TITLE
Add set() to update set shopping attributes

### DIFF
--- a/src/lib/shopping-analytics.js
+++ b/src/lib/shopping-analytics.js
@@ -9,6 +9,8 @@ import {
   type EventToFptiInputMapping
 } from './shopping-event-conversions';
 import { setUser } from './user-configuration';
+import { shoppingAttributes } from './shopping-attributes';
+
 
 const initEventPublisher = (config : Config) => {
   const fptiEventPubisher = ShoppingEventPublisher(config);
@@ -25,7 +27,8 @@ function initGenericEventPublisher(config : Config) : Object {
   const convertEvent = eventToFptiConverters(config).eventToFpti;
   return {
     publishEvent: (event : EventType, payload : Object) => {
-      const fptiInput : FptiInput = convertEvent(event, payload);
+      const extendedPayload = { ...payload, ...config.shoppingAttributes };
+      const fptiInput : FptiInput = convertEvent(event, extendedPayload);
       fptiEventPubisher.publishFptiEvent(fptiInput);
     }
   };
@@ -52,5 +55,6 @@ export const setupTrackers = (config : Config) => {
   const viewPage = eventPublisher(converters.viewPageToFpti);
   const viewProduct = eventPublisher(converters.viewProductToFpti);
   const send = initGenericEventPublisher(config).publishEvent;
-  return { viewPage, viewProduct, send, setUser, autoGenerateProductPayload };
+  const set = shoppingAttributes(config).updateShoppingAttributes;
+  return { viewPage, viewProduct, send, setUser, set, autoGenerateProductPayload };
 };

--- a/src/lib/shopping-attributes.js
+++ b/src/lib/shopping-attributes.js
@@ -1,0 +1,21 @@
+/* @flow */
+import type { Config } from '../types';
+
+
+/**
+ * Sets up a page context object that uses Config object to store variables within the page scope.
+ * Currently, there is no constraint on the varables (name,value). the set of supported vairables will be described
+ * in the SDK documentation. Primary reason, for not having any restriction is to build a generic interafce for vairables and
+ * once we clear about the supported list of vairables, the constraint maybe added.
+ *
+ * @param config
+ * @returns {{viewPage: (function(...[*]=))}}
+ */
+export function shoppingAttributes (config : Config) : Object {
+  return {
+    updateShoppingAttributes: (variables : Object) =>  {
+      const priorAttributes = config.shoppingAttributes || {};
+      config.shoppingAttributes = { ...priorAttributes, ...variables };
+    }
+  };
+}

--- a/src/types/config.js
+++ b/src/types/config.js
@@ -23,7 +23,8 @@ export type Config = {|
     |},
     containerSummary? : ContainerSummary | null,
     paramsToPropertyIdUrl? : ParamsToPropertyIdUrl,
-    currencyCode? : string
+    currencyCode? : string,
+    shoppingAttributes? : Object
 |};
 
 export type JetloreConfig = {|

--- a/test/lib/shopping-analytics.test.js
+++ b/test/lib/shopping-analytics.test.js
@@ -77,9 +77,27 @@ describe('test eventTracker setup', () => {
     expect(fptiPublishMock).toBeCalledWith(mockFptiInput);
   });
 
+  it('should send() handle generic event include shopping attributes', () => {
+    config.shoppingAttributes = { dummyAttrib: 'test' };
+    const trackers = setupTrackers(config);
+    
+    trackers.send('testEvent', productView);
+
+    const expectedPayload = { ...productView, dummyAttrib: 'test' };
+    expect(eventToFptiMock).toBeCalledWith('testEvent', expectedPayload);
+
+    expect(fptiPublishMock).toBeCalledWith(mockFptiInput);
+  });
+
   it('should include autoGenerateProductPayload', () => {
     const trackers = setupTrackers(config);
     expect(trackers.autoGenerateProductPayload).toBeInstanceOf(Function);
+  });
+
+  it('should update shopping attributes. set() ', () => {
+    const trackers = setupTrackers(config);
+    trackers.set({ dummyAttrib: '1234' });
+    expect(config.shoppingAttributes).toEqual({ dummyAttrib: '1234' });
   });
 
 });


### PR DESCRIPTION
Provide a new method in SDK - set(), to set any shopping variables that will be included  in the events. 
Currently, these settings are per page context.