### PR TITLE
Set user v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/muse-components",
-  "version": "1.3.52",
+  "version": "1.3.53",
   "description": "MUSE component for unified PayPal/Braintree web sdk",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/muse-components",
-  "version": "1.3.50",
+  "version": "1.3.51",
   "description": "MUSE component for unified PayPal/Braintree web sdk",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/muse-components",
-  "version": "1.3.51",
+  "version": "1.3.52",
   "description": "MUSE component for unified PayPal/Braintree web sdk",
   "main": "index.js",
   "scripts": {

--- a/src/lib/shopping-analytics.js
+++ b/src/lib/shopping-analytics.js
@@ -8,7 +8,6 @@ import {
   eventToFptiConverters,
   type EventToFptiInputMapping
 } from './shopping-event-conversions';
-import { setUser } from './user-configuration';
 import { shoppingAttributes } from './shopping-attributes';
 
 
@@ -56,5 +55,5 @@ export const setupTrackers = (config : Config) => {
   const viewProduct = eventPublisher(converters.viewProductToFpti);
   const send = initGenericEventPublisher(config).publishEvent;
   const set = shoppingAttributes(config).updateShoppingAttributes;
-  return { viewPage, viewProduct, send, setUser, set, autoGenerateProductPayload };
+  return { viewPage, viewProduct, send, set, autoGenerateProductPayload };
 };

--- a/src/lib/shopping-event-conversions.js
+++ b/src/lib/shopping-event-conversions.js
@@ -28,18 +28,17 @@ function convertShoppingEventToFptiInput(
   eventType : EventType
 ) : FptiInput {
 
-  if (!event.user) {
-    event.user = config.user;
-  }
-
   const storedUserIds = getStoredUserIds();
 
+  const eventDataPayload = { ...event };
+  // remove user_id property from event_payload since it is passed separately
+  delete eventDataPayload.user_id;
   const data : FptiInput = {
     eventName: eventType,
     eventType,
-    eventData: JSON.stringify(event),
+    eventData: JSON.stringify(eventDataPayload),
     shopperId: storedUserIds.shopperId,
-    merchantProvidedUserId: storedUserIds.merchantProvidedUserId
+    merchantProvidedUserId: event.user_id
   };
 
   return data;

--- a/src/lib/user-configuration.js
+++ b/src/lib/user-configuration.js
@@ -1,5 +1,5 @@
 /* @flow */
-import type { Config, UserData } from '../types';
+import type { Config } from '../types';
 
 import {
   getOrCreateValidUserId as fetchOrSetupUserIdInLocalStorage,
@@ -56,8 +56,4 @@ export const setupUserDetails = (config : Config) => {
   // $FlowFixMe
     config.user.id = userId;
   }
-};
-
-export const setUser = (user : UserData) => {
-  setupUserDetails({ user });
 };

--- a/src/types/shopping-events.js
+++ b/src/types/shopping-events.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-export type EventType = 'pageView' | 'productView' | 'purchase' | 'setUser' | 'cancelCart' | 'customEvent';
+export type EventType = 'pageView' | 'productView' | 'purchase' | 'cancelCart' | 'customEvent';
 
 export type PageView = {|
     id? : string,

--- a/test/lib/shopping-event-conversions.test.js
+++ b/test/lib/shopping-event-conversions.test.js
@@ -43,39 +43,71 @@ describe('test event converters to FPTI input', () => {
     getUserId.mockClear();
     getUserId.mockReturnValue({ userId: generatedUserId, merchantProvidedUserId });
   });
-  it('should map HOME_PAGE pageView event with optional fields to FPTI input', () => {
-    const fptiEvent = eventConverters.viewPageToFpti(pageView);
-    expect(fptiEvent.eventName).toEqual('pageView');
-    expect(fptiEvent.eventType).toEqual('pageView');
-    expect(fptiEvent.eventData).toEqual(JSON.stringify(pageView));
-    expect(fptiEvent.shopperId).toEqual(generatedUserId);
-    expect(fptiEvent.merchantProvidedUserId).toEqual(merchantProvidedUserId);
+
+  describe('viewPageToFpti', () => {
+    it('should map HOME_PAGE pageView event with optional fields to FPTI input', () => {
+      const fptiEvent = eventConverters.viewPageToFpti(pageView);
+      expect(fptiEvent.eventName).toEqual('pageView');
+      expect(fptiEvent.eventType).toEqual('pageView');
+      expect(fptiEvent.eventData).toEqual(JSON.stringify(pageView));
+      expect(fptiEvent.shopperId).toEqual(generatedUserId);
+    });
+
+    it('should map HOME_PAGE pageView event without optional fields to FPTI input', () => {
+      const fptiEvent = eventConverters.viewPageToFpti(pageViewSimple);
+      expect(fptiEvent.eventName).toEqual('pageView');
+      expect(fptiEvent.eventType).toEqual('pageView');
+      expect(fptiEvent.eventData).toEqual(JSON.stringify(pageViewSimple));
+      expect(fptiEvent.shopperId).toEqual(generatedUserId);
+    });
   });
 
-  it('should map HOME_PAGE pageView event without optional fields to FPTI input', () => {
-    const fptiEvent = eventConverters.viewPageToFpti(pageViewSimple);
-    expect(fptiEvent.eventName).toEqual('pageView');
-    expect(fptiEvent.eventType).toEqual('pageView');
-    expect(fptiEvent.eventData).toEqual(JSON.stringify(pageViewSimple));
-    expect(fptiEvent.shopperId).toEqual(generatedUserId);
-    expect(fptiEvent.merchantProvidedUserId).toEqual(merchantProvidedUserId);
+  describe('viewProductToFpti', () => {
+    it('should map productView event to FPTI input', () => {
+      const fptiEvent = eventConverters.viewProductToFpti(productView);
+      expect(fptiEvent.eventName).toEqual('productView');
+      expect(fptiEvent.eventType).toEqual('productView');
+      expect(fptiEvent.eventData).toEqual(JSON.stringify(productView));
+      expect(fptiEvent.shopperId).toEqual(generatedUserId);
+    });
   });
 
-  it('should map productView event to FPTI input', () => {
-    const fptiEvent = eventConverters.viewProductToFpti(productView);
-    expect(fptiEvent.eventName).toEqual('productView');
-    expect(fptiEvent.eventType).toEqual('productView');
-    expect(fptiEvent.eventData).toEqual(JSON.stringify(productView));
-    expect(fptiEvent.shopperId).toEqual(generatedUserId);
-    expect(fptiEvent.merchantProvidedUserId).toEqual(merchantProvidedUserId);
+  describe('eventToFpti', () => {
+    it('should map generic event to FPTI input', () => {
+      const fptiEvent = eventConverters.eventToFpti('productView', productView);
+      expect(fptiEvent.eventName).toEqual('productView');
+      expect(fptiEvent.eventType).toEqual('productView');
+      expect(fptiEvent.eventData).toEqual(JSON.stringify(productView));
+      expect(fptiEvent.shopperId).toEqual(generatedUserId);
+    });
+
+    it('should map merchantProvidedUserId to FPTI input when user_id is set', () => {
+      const userId = '123';
+      const payload = {
+        user_id: userId,
+        id: 'HOME'
+      };
+      const eventDataPayload = { ...payload };
+      delete eventDataPayload.user_id;
+      const fptiEvent = eventConverters.eventToFpti('page_view', payload);
+      expect(fptiEvent.eventName).toEqual('page_view');
+      expect(fptiEvent.eventType).toEqual('page_view');
+      expect(fptiEvent.eventData).toEqual(JSON.stringify(eventDataPayload));
+      expect(fptiEvent.shopperId).toEqual(generatedUserId);
+      expect(fptiEvent.merchantProvidedUserId).toEqual(userId);
+    });
+
+    it('should not map merchantProvidedUserId to FPTI input when user_id is not set', () => {
+      const payload = { id: 'HOME' };
+      const eventDataPayload = { ...payload };
+      delete eventDataPayload.user_id;
+      const fptiEvent = eventConverters.eventToFpti('page_view', payload);
+      expect(fptiEvent.eventName).toEqual('page_view');
+      expect(fptiEvent.eventType).toEqual('page_view');
+      expect(fptiEvent.eventData).toEqual(JSON.stringify(eventDataPayload));
+      expect(fptiEvent.shopperId).toEqual(generatedUserId);
+      expect(fptiEvent.merchantProvidedUserId).toEqual(undefined);
+    });
   });
 
-  it('should map generic event to FPTI input', () => {
-    const fptiEvent = eventConverters.eventToFpti('productView', productView);
-    expect(fptiEvent.eventName).toEqual('productView');
-    expect(fptiEvent.eventType).toEqual('productView');
-    expect(fptiEvent.eventData).toEqual(JSON.stringify(productView));
-    expect(fptiEvent.shopperId).toEqual(generatedUserId);
-    expect(fptiEvent.merchantProvidedUserId).toEqual(merchantProvidedUserId);
-  });
 });

--- a/test/lib/user-configuration.test.js
+++ b/test/lib/user-configuration.test.js
@@ -1,6 +1,6 @@
 /* global expect jest */
 /* @flow */
-import { setupUserDetails, setUser } from '../../src/lib/user-configuration';
+import { setupUserDetails } from '../../src/lib/user-configuration';
 import {
   getOrCreateValidUserId,
   setGeneratedUserId,
@@ -49,16 +49,5 @@ describe('sets up user details', () => {
     expect(createNewCartId).toHaveBeenCalledTimes(1);
     expect(setGeneratedUserId).toHaveBeenCalledTimes(1);
     expect(config.user.id).toEqual(mockedUserId);
-  });
-
-  it('should set up user details for configuration with user details passed to setUser', () => {
-    const user = { id: 'test_user' };
-    setUser(user);
-    const config = { user };
-    expect(IdentityManager).toBeCalledWith(config);
-    expect(getOrCreateValidUserId).toHaveBeenCalledTimes(1);
-    expect(config.user.id).toEqual(mockedUserId);
-    expect(setMerchantProvidedUserId).toBeCalledWith('test_user');
-    expect(config.user.merchantProvidedUserId).toEqual('test_user');
   });
 });


### PR DESCRIPTION
**JIRA:**
DTSHOPSDK-366

**Changes:**
Changed overall way we expect merchants to set known user ID. Did this by removing `setUser` method and instead expecting `set` method to be called with `user_id` property.

**Example 1 (no user ID set by merchant):**

Merchant calls:

```
const t = PayPalShoppingSDK.ShoppingAnalytics();
t.send('page_view', { id: 'HOME' });
```

Sample of relevant merchant properties:

```
sinfo: "{\"id\":\"HOME\"}"
shopper_id: "uid_6f9a2e15eb_mtc6mzq6mza"
product: "ppshopping_v2"
external_id: undefined
```

**Example 2 (user ID set by merchant):**

Merchant calls:

```
const t = PayPalShoppingSDK.ShoppingAnalytics();
t.set({ user_id: '123' });
t.send('page_view', { id: 'HOME' });
```

Sample of relevant merchant properties:

```
sinfo: "{\"id\":\"HOME\"}"
shopper_id: "uid_6f9a2e15eb_mtc6mzq6mza"
product: "ppshopping_v2"
external_id: "123"
```