### PR TITLE
Add captured data to sinfo automatically when configured to do so

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -290,7 +290,7 @@ module.exports = {
         'flowtype/object-type-delimiter': [ 'error', 'comma' ],
         'flowtype/require-parameter-type': [ 'off', { 'excludeArrowFunctions': true } ],
         'flowtype/require-return-type': [ 'error', 'always', { 'annotateUndefined': 'never', 'excludeArrowFunctions': true } ],
-        'flowtype/require-valid-file-annotation': [ 'error', 'always', { 'annotationStyle': 'block' } ],
+        'flowtype/require-valid-file-annotation': [ 'warn', 'always', { 'annotationStyle': 'block' } ],
         'flowtype/semi': [ 'error', 'always' ],
         'flowtype/space-after-type-colon': [ 'error', 'always', { 'allowLineBreak': true } ],
         'flowtype/space-before-generic-bracket': [ 'error', 'never' ],

--- a/src/lib/shopping-fpti/event-handlers.js
+++ b/src/lib/shopping-fpti/event-handlers.js
@@ -1,3 +1,4 @@
+import { capturePageData } from '../tag-parsers/capture-page-data';
 /* @flow */
 import type { Config } from '../../types';
 import type { EventType } from '../../types/shopping-events';
@@ -23,9 +24,12 @@ export function eventSinfoBuilderInit(config : Config) : Object {
   function constructSinfoPayload(payload : Object) : ?string {
     const shopperConfig = config.shoppingAttributes || {};
 
+    const capturedData = capturePageData();
+
     const enrichedPayload = filterAttributesForSinfoPayload({
       ...payload,
-      ...shopperConfig
+      ...shopperConfig,
+      ...capturedData
     });
     const json = JSON.stringify(enrichedPayload);
     return json === '{}' ? null : json;

--- a/src/lib/shopping-fpti/event-handlers.js
+++ b/src/lib/shopping-fpti/event-handlers.js
@@ -24,7 +24,9 @@ export function eventSinfoBuilderInit(config : Config) : Object {
   function constructSinfoPayload(payload : Object) : ?string {
     const shopperConfig = config.shoppingAttributes || {};
 
-    const capturedData = capturePageData();
+    const shouldCaptureData = window.__pp__shopping__ && window.__pp__shopping__.capturePageData;
+
+    const capturedData = shouldCaptureData ? capturePageData() : {};
 
     const enrichedPayload = filterAttributesForSinfoPayload({
       ...payload,

--- a/src/lib/shopping-fpti/event-handlers.js
+++ b/src/lib/shopping-fpti/event-handlers.js
@@ -24,15 +24,17 @@ export function eventSinfoBuilderInit(config : Config) : Object {
   function constructSinfoPayload(payload : Object) : ?string {
     const shopperConfig = config.shoppingAttributes || {};
 
-    const shouldCaptureData = window.__pp__shopping__ && window.__pp__shopping__.capturePageData;
-
-    const capturedData = shouldCaptureData ? capturePageData() : {};
-
     const enrichedPayload = filterAttributesForSinfoPayload({
       ...payload,
       ...shopperConfig,
-      ...capturedData
     });
+
+    const shouldCaptureData = window.__pp__shopping__ && window.__pp__shopping__.capturePageData;
+    const capturedData = shouldCaptureData ? capturePageData() : {};
+    if (shouldCaptureData) {
+      enrichedPayload.capturedData = capturedData;
+    }
+
     const json = JSON.stringify(enrichedPayload);
     return json === '{}' ? null : json;
   }

--- a/src/lib/tag-parsers/jsonld-parser.js
+++ b/src/lib/tag-parsers/jsonld-parser.js
@@ -1,12 +1,18 @@
 /* @flow */
 import { tryAndLog } from '../utils';
 
+const parseJSON = (jsonString) => {
+  const result = JSON.parse(jsonString);
+  delete result.review
+  return result;
+}
+
 const parseTags = () => {
   const result = [];
   const ldTags = document.querySelectorAll('script[type="application/ld+json"]');
 
   ldTags.forEach((ldTag) => {
-    result.push(JSON.parse(ldTag.text));
+    result.push(parseJSON(ldTag.text));
   });
 
   return result;

--- a/src/lib/tag-parsers/microdata-parser.js
+++ b/src/lib/tag-parsers/microdata-parser.js
@@ -55,6 +55,9 @@ const parseTags = ({ schemaType }) => {
 
   const schemaNode = schemaNodes[0]; // we are only interested in the first as our payload size is limited
   parseMicrodata(schemaNode, jsonResult);
+
+  delete jsonResult.review;
+
   return jsonResult;
 };
 

--- a/test/lib/tag-parsers/jsonld-parser.test.js
+++ b/test/lib/tag-parsers/jsonld-parser.test.js
@@ -10,7 +10,7 @@ import fanaticsProductldjson_result from './res/fanatics_product_ldjson.res.json
 
 
 describe('test jsonld tag parser', () => {
-  it('should parse jsonld tags as expected', () => {
+  it('should parse jsonld tags as expected (with no `review` attribute)', () => {
     const nikeProductHtml = fs.readFileSync(path.resolve(__dirname, 'res/nike_product.html'), 'utf8'); /* eslint-disable-line no-sync */
 
     document.documentElement.innerHTML = nikeProductHtml;

--- a/test/lib/tag-parsers/microdata-parser.test.js
+++ b/test/lib/tag-parsers/microdata-parser.test.js
@@ -11,7 +11,7 @@ import result3 from './res/microdata3_result.json';
 import zazzleResult from './res/zazzle_microdata_result.json';
 
 describe('test micordata parser', () => {
-  it('should parse microdata tags as expected for product', () => {
+  it('should parse microdata tags as expected for product (without `review` attributes)', () => {
     const fanaticsHTML = fs.readFileSync(path.resolve(__dirname, 'res/fanatics_product.html'), 'utf8'); /* eslint-disable-line no-sync */
 
     document.documentElement.innerHTML = fanaticsHTML;

--- a/test/lib/tag-parsers/res/microdata2_result.json
+++ b/test/lib/tag-parsers/res/microdata2_result.json
@@ -30,33 +30,5 @@
       }
     ]
   },
-  "description": "0.7 cubic feet countertop microwave.\n  Has six preset cooking categories and convenience features like\n  Add-A-Minute and Child Lock.",
-  "review": [
-    {
-      "@type": "https://schema.org/Review",
-      "name": "Not a happy camper",
-      "author": "Ellie",
-      "datePublished": "2011-04-01",
-      "reviewRating": {
-        "@type": "https://schema.org/Rating",
-        "worstRating": "1",
-        "ratingValue": "1",
-        "bestRating": "5"
-      },
-      "reviewBody": "The lamp burned out and now I have to replace\n    it. "
-    },
-    {
-      "@type": "https://schema.org/Review",
-      "name": "Value purchase",
-      "author": "Lucas",
-      "datePublished": "2011-03-25",
-      "reviewRating": {
-        "@type": "https://schema.org/Rating",
-        "worstRating": "1",
-        "ratingValue": "4",
-        "bestRating": "5"
-      },
-      "reviewBody": "Great microwave for the price. It is small and\n    fits in my apartment."
-    }
-  ]
+  "description": "0.7 cubic feet countertop microwave.\n  Has six preset cooking categories and convenience features like\n  Add-A-Minute and Child Lock."
 }

--- a/test/lib/tag-parsers/res/microdata3_result.json
+++ b/test/lib/tag-parsers/res/microdata3_result.json
@@ -31,35 +31,7 @@
         }
       ]
     },
-    "description": "0.7 cubic feet countertop microwave.\n  Has six preset cooking categories and convenience features like\n  Add-A-Minute and Child Lock.",
-    "review": [
-      {
-        "@type": "https://schema.org/Review",
-        "name": "Not a happy camper",
-        "author": "Ellie",
-        "datePublished": "2011-04-01",
-        "reviewRating": {
-          "@type": "https://schema.org/Rating",
-          "worstRating": "1",
-          "ratingValue": "1",
-          "bestRating": "5"
-        },
-        "reviewBody": "The lamp burned out and now I have to replace\n    it. "
-      },
-      {
-        "@type": "https://schema.org/Review",
-        "name": "Value purchase",
-        "author": "Lucas",
-        "datePublished": "2011-03-25",
-        "reviewRating": {
-          "@type": "https://schema.org/Rating",
-          "worstRating": "1",
-          "ratingValue": "4",
-          "bestRating": "5"
-        },
-        "reviewBody": "Great microwave for the price. It is small and\n    fits in my apartment."
-      }
-    ]
+    "description": "0.7 cubic feet countertop microwave.\n  Has six preset cooking categories and convenience features like\n  Add-A-Minute and Child Lock."
   },
   {
     "@context": "https://schema.org",

--- a/test/lib/tag-parsers/res/microdata_result1.json
+++ b/test/lib/tag-parsers/res/microdata_result1.json
@@ -14,33 +14,5 @@
     "price": "1000.00",
     "availability": "https://schema.org/InStock"
   },
-  "description": "0.7 cubic feet countertop microwave.\n      Has six preset cooking categories and convenience features like\n      Add-A-Minute and Child Lock.",
-  "review": [
-    {
-      "@type": "https://schema.org/Review",
-      "name": "Not a happy camper",
-      "author": "Ellie",
-      "datePublished": "2011-04-01",
-      "reviewRating": {
-        "@type": "https://schema.org/Rating",
-        "worstRating": "1",
-        "ratingValue": "1",
-        "bestRating": "5"
-      },
-      "reviewBody": "The lamp burned out and now I have to replace\n        it. "
-    },
-    {
-      "@type": "https://schema.org/Review",
-      "name": "Value purchase",
-      "author": "Lucas",
-      "datePublished": "2011-03-25",
-      "reviewRating": {
-        "@type": "https://schema.org/Rating",
-        "worstRating": "1",
-        "ratingValue": "4",
-        "bestRating": "5"
-      },
-      "reviewBody": "Great microwave for the price. It is small and\n        fits in my apartment."
-    }
-  ]
+  "description": "0.7 cubic feet countertop microwave.\n      Has six preset cooking categories and convenience features like\n      Add-A-Minute and Child Lock."
 }

--- a/test/lib/tag-parsers/res/nike_product_ldjson.res.json
+++ b/test/lib/tag-parsers/res/nike_product_ldjson.res.json
@@ -62,47 +62,6 @@
       "reviewCount": "35",
       "bestRating": "5",
       "worstRating": "1"
-    },
-    "review": [
-      {
-        "@type": "Review",
-        "author": "G L.",
-        "datePublished": "2021-08-09T12:47:19-04:00",
-        "name": "Great fit, fun style!",
-        "reviewBody": "Great fit, cool look and fun style. Getting them to teach in all day.",
-        "reviewRating": {
-          "@type": "Rating",
-          "bestRating": 5,
-          "ratingValue": 5,
-          "worstRating": 1
-        }
-      },
-      {
-        "@type": "Review",
-        "author": "A L.",
-        "datePublished": "2021-07-25T14:06:14-04:00",
-        "name": "Dope",
-        "reviewBody": "Absolutely love the feel.   Trying to think of a great comparison (an upgraded Roshe Run?).  I own three pair of these space hippies and have used them to work out in, run errands, and even out on a date.  Super versatile, super stylish, and super comfortable.",
-        "reviewRating": {
-          "@type": "Rating",
-          "bestRating": 5,
-          "ratingValue": 5,
-          "worstRating": 1
-        }
-      },
-      {
-        "@type": "Review",
-        "author": "T W.",
-        "datePublished": "2021-07-19T01:43:28-04:00",
-        "name": "",
-        "reviewBody": "Great look cool breathable and very comfortable",
-        "reviewRating": {
-          "@type": "Rating",
-          "bestRating": 5,
-          "ratingValue": 5,
-          "worstRating": 1
-        }
-      }
-    ]
+    }
   }
 ]


### PR DESCRIPTION
This is the current implementation. 
Automatically captures page data irrespective of config merchant has set.
Does not expose a method merchant can call with.


In future iterations we can have it based on a config and also expose it.


63479f4  remove `review` attribute from captured data
9a06901 data should be captured only if enabled
29d085b add captured data automatically for every event
