### PR TITLE
chore: master to main for ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,8 @@
 name: build
 on:
-  # run on push but only for the main branch
   push:
     branches:
-      - master
-  # run for every pull request
+      - main
   pull_request: {}
 jobs:
   main:
@@ -28,6 +26,6 @@ jobs:
 
       - name: ▶️ Run test script
         run: npm run test
-        
+
       - name: ⬆️ Upload jest coverage report
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
will update the github repo settings after merging and then locally folks will have to do the updates to point their repos to main. 

Below is typically all that is needed to be run locally.
```sh
git branch -m master main
```