### PR TITLE
Dtshopseol 1489

### DIFF
--- a/__sdk__.js
+++ b/__sdk__.js
@@ -1,6 +1,8 @@
 /* @flow */
 /* eslint import/no-commonjs: 0 */
 
+const globals = require('./globals');
+
 module.exports = {
   messaging: {
     entry: './src/messaging',
@@ -16,6 +18,7 @@ module.exports = {
   },
   shopping: {
     entry: './src/shopping',
+    globals,
     automatic: false
   }
 };

--- a/globals.js
+++ b/globals.js
@@ -1,0 +1,15 @@
+const zoidGlobals = require('@krakenjs/zoid/globals');
+const postRobotGlobals = require('@krakenjs/post-robot/globals');
+
+module.exports = {
+  __ZOID__: {
+    ...zoidGlobals.__ZOID__,
+    __FRAMEWORK_SUPPORT__: true,
+    __SCRIPT_NAMESPACE__:  true
+  },
+  __POST_ROBOT__: {
+    ...postRobotGlobals.__POST_ROBOT__,
+    __IE_POPUP_SUPPORT__: false,
+    __SCRIPT_NAMESPACE__: true
+  },
+}

--- a/globals.js
+++ b/globals.js
@@ -1,3 +1,4 @@
+/* eslint import/no-commonjs: 0 */
 const zoidGlobals = require('@krakenjs/zoid/globals');
 const postRobotGlobals = require('@krakenjs/post-robot/globals');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/muse-components",
-  "version": "1.3.86",
+  "version": "1.3.87",
   "description": "MUSE component for unified PayPal/Braintree web sdk",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "files": [
     "src",
-    "__sdk__.js"
+    "__sdk__.js",
+    "globals.js"
   ],
   "repository": {
     "type": "git",
@@ -34,7 +35,7 @@
   },
   "homepage": "https://github.com/paypal/paypal-muse-components#readme",
   "devDependencies": {
-    "@krakenjs/grumbler-scripts": "^8.0.4",
+    "@krakenjs/grumbler-scripts": "^8.0.7",
     "express": "^4.17.1",
     "flow-bin": "^0.100.0",
     "flow-typed": "3.3.1",
@@ -47,6 +48,8 @@
   },
   "dependencies": {
     "@krakenjs/belter": "^2.0.1",
+    "@krakenjs/zoid": "^10.0.0",
+    "@krakenjs/post-robot": "^11.0.0",
     "@paypal/sdk-client": "^4.0.166",
     "whatwg-fetch": "^3.0.0"
   },


### PR DESCRIPTION
### What was done
* override __SCRIPT_NAMESPACE__ default settings for POST_ROBOT and ZOID
* add `@krakenjs/zoid` and `@krakenjs/post-robot` as npm dependency, because we need override only specific settings in this libraries

### Problem
when 2 or more instances of muse component was included on a page, sdk throws error: "namespace already in use"

### Root cause
After update, POST_ROBOT and ZOID use default namespace if it wasn't specified. It is causing conflict.

### Solution
Override ZOID and POST_ROBOT default settings. They will use unique namespace from now instead of default